### PR TITLE
ECS-390: add ComponentPropertyControlSlider to component property con…

### DIFF
--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -220,22 +220,10 @@ export interface ComponentPropertyControlInteractive {
 
 export interface ComponentPropertyControlSlider {
     type: 'slider';
-
-    /**
-     * Minimum value
-     */
-    minValue: number;
-    /**
-     * Maximum value
-     */
-    maxValue: number;
-    /**
-     * Default value
-     */
+    value?: number;
+    minValue?: number;
+    maxValue?: number;
     defaultValue?: number;
-    /**
-     * Step
-     */
     step?: number;
 }
 

--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -16,7 +16,8 @@ export type ComponentPropertyControl =
     | ComponentPropertyControlInteractive
     | ComponentPropertyControlHeader
     | ComponentPropertyControlTextArea
-    | ComponentPropertyControlUrl;
+    | ComponentPropertyControlUrl
+    | ComponentPropertyControlSlider;
 
 /**
  * Dropdown with fixed number of options
@@ -215,6 +216,27 @@ export interface ComponentPropertyControlInteractive {
      * A link which is used to show the directive
      */
     viewLink: string;
+}
+
+export interface ComponentPropertyControlSlider {
+    type: 'slider';
+
+    /**
+     * Minimum value
+     */
+    minValue: number;
+    /**
+     * Maximum value
+     */
+    maxValue: number;
+    /**
+     * Default value
+     */
+    defaultValue?: number;
+    /**
+     * Step
+     */
+    step?: number;
 }
 
 /**


### PR DESCRIPTION
I added ComponentPropertyControlSlider support here to be able to create a property definition in DE with type `slider:`
`import { ComponentProperty } from '@woodwing/csde-components-validator/dist/models';`