### PR TITLE
scout: mark package as side effect free.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@woodwing/studio-component-set-tools",
   "version": "1.0.0",
   "description": "Tools module for Studio Digital Editor component sets packages.",
+  "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Can be used by Webpack tree shaking to reduce bundle size.
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free