### PR TITLE
CSH-8048: only allow nameless properties for header properties.

### DIFF
--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -11,6 +11,7 @@ describe('PropertiesValidator', () => {
             version: '1.0.0',
             components: {
                 c1: {
+                    name: 'c1',
                     properties: [
                         {
                             name: 'p1',
@@ -36,6 +37,7 @@ describe('PropertiesValidator', () => {
                 },
                 // Add another component with same property to test uniqueness validation passes correctly
                 c2: {
+                    name: 'c2',
                     properties: [
                         {
                             name: 'p1',
@@ -83,12 +85,26 @@ describe('PropertiesValidator', () => {
             validator.validate();
             expect(error).not.toHaveBeenCalled();
         });
-        it('should pass if several properties have no name', () => {
+
+        it('should pass if there are multiple nameless properties of control type "header" in same component', () => {
             definition.version = '1.5.0';
-            definition.components.c1.properties[0].name = undefined;
-            definition.components.c1.properties[1].name = undefined;
+            definition.components.c1.properties.push({ label: 'Header', control: { type: 'header' } });
+            definition.components.c1.properties.push({ label: 'Another Header', control: { type: 'header' } });
             validator.validate();
             expect(error).not.toHaveBeenCalled();
+        });
+
+        it('should not pass if properties that save data have no name', () => {
+            definition.version = '1.5.0';
+            delete definition.components.c1.properties[0].name;
+            delete definition.components.c1.properties[2].name;
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(
+                `Property in component "c1" must have a name when using control type "text"`,
+            );
+            expect(error).toHaveBeenCalledWith(
+                `Property in component "c1" must have a name when using control type "media-properties"`,
+            );
         });
     });
 });


### PR DESCRIPTION
The only type of property that should be allowed without name is the header, which does not save data
into the article. Other properties require a name, as it is used as the key for data saving.

I start to feel we should also have a fresh look at the validators structure:
- The tests feel a bit clumsy. I would rather have tools to create real component set structures in an easy way, rather than these incomplete snippets.
- The validators itself could use more structure, like I now need to pass through the ParsedComponent reference to build the error message.
- We need a way to easily show where the user made the mistake, with line numbers in the components-definition.json. Acting on the parsed ComponentSet structure might make this hard though.