### PR TITLE
ECS-395 parse child properties

### DIFF
--- a/lib/models/components-definition.ts
+++ b/lib/models/components-definition.ts
@@ -159,6 +159,12 @@ export interface ComponentProperty {
 
     /** Feature flag that should be present for the property to show up. Always show if not specified. */
     featureFlag?: string;
+
+    childProperties?: {
+        matchType: string;
+        matchExpression?: string | number | boolean;
+        properties: (string | ComponentProperty)[];
+    }[];
 }
 
 /** Component group definition. */

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -268,6 +268,29 @@ function buildComponentDefaultContent(
 ): void {
     for (const property of component.properties) {
         buildComponentPropertyDefaultContent(defaultComponentContent, component.name, property);
+        buildConditionalChildPropertiesDefaultContent(defaultComponentContent, component.name, property);
+    }
+}
+
+function buildConditionalChildPropertiesDefaultContent(
+    defaultComponentContent: ComponentSet['defaultComponentContent'],
+    componentName: string,
+    property: ComponentProperty,
+) {
+    if (!property.childProperties || property.childProperties.length === 0) return;
+
+    const childProperties = property.childProperties.find(
+        (candidate) => candidate.matchExpression === property.defaultValue,
+    );
+
+    if (!childProperties) return;
+
+    for (const childProperty of childProperties.properties) {
+        buildComponentPropertyDefaultContent(
+            defaultComponentContent,
+            componentName,
+            childProperty as ComponentProperty,
+        );
     }
 }
 

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -4,17 +4,17 @@
 
 import * as path from 'path';
 import * as htmlparser from 'htmlparser2';
-import merge = require('lodash.merge');
 import {
-    DirectiveType,
-    ComponentSet,
-    ComponentsDefinition,
     Component,
-    ParsedComponent,
     ComponentProperty,
     ComponentRendition,
+    ComponentsDefinition,
+    ComponentSet,
+    DirectiveType,
     GetFileContentType,
+    ParsedComponent,
 } from '../models';
+import merge = require('lodash.merge');
 
 /**
  * Parses the components definition into the object which contains all needed data to make needed validations
@@ -159,14 +159,8 @@ function parseComponent(
         directives: directives,
         properties: (component.properties || []).map((componentProperty) => {
             const property = parseProperty(componentProperty, componentProperties);
-
-            if (property.directiveKey && !(property.directiveKey in directives)) {
-                throw new Error(
-                    `Directive with key "${property.directiveKey}" is not found in component "${
-                        component.name
-                    }". Property name is "${property.name || '<anonymous property>'}".`,
-                );
-            }
+            validateDirective(property.directiveKey, directives, component.name, property.name);
+            parseConditionalChildProperties(property, componentProperties, directives, component.name);
             return property;
         }),
         noCreatePermission: false,
@@ -206,6 +200,39 @@ function findComponentPropertyTemplate(propertyName: string, componentProperties
 
 function isPropertyObject(property: unknown): property is ComponentProperty {
     return property instanceof Object;
+}
+
+function parseConditionalChildProperties(
+    property: ComponentProperty,
+    componentProperties: ComponentProperty[],
+    directives: ComponentSet['components']['name']['directives'],
+    componentName: string,
+) {
+    if (!property.childProperties || property.childProperties.length === 0) return;
+
+    property.childProperties = property.childProperties.map((conditionalChildProperties) => ({
+        ...conditionalChildProperties,
+        properties: conditionalChildProperties.properties.map((componentProperty) => {
+            const childProperty = parseProperty(componentProperty, componentProperties);
+            validateDirective(childProperty.directiveKey, directives, componentName, childProperty.name);
+            return childProperty;
+        }),
+    }));
+}
+
+function validateDirective(
+    directiveKey: string | undefined,
+    directives: ComponentSet['components']['name']['directives'],
+    componentName: string,
+    propertyName: string,
+) {
+    if (directiveKey && !(directiveKey in directives)) {
+        throw new Error(
+            `Directive with key "${directiveKey}" is not found in component "${componentName}". Property name is "${
+                propertyName || '<anonymous property>'
+            }".`,
+        );
+    }
 }
 
 /**

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -58,7 +58,7 @@ import {
 } from './validators';
 import { listFilesRelativeToFolder } from './util/files';
 
-const ajvInstance = new ajv({ allErrors: true, verbose: true });
+const ajvInstance = new ajv({ allErrors: true, verbose: true, allowUnionTypes: true });
 addFormats(ajvInstance);
 
 const componentsDefinitionPath = path.normalize('./components-definition.json');

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/htmlparser2": "3.7.31",
     "@types/jest": "^26.0.0",
+    "@types/json-schema": "~7.0.7",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/node": "^12.12.6",

--- a/test/parser/parser-util.child-properties.test.ts
+++ b/test/parser/parser-util.child-properties.test.ts
@@ -257,4 +257,28 @@ describe('Parser utils child properties', () => {
         // console.warn(JSON.stringify(componentSet, null, 4));
         expect(componentSet).toEqual(expectedComponentSet);
     });
+
+    it('should add default content of default child property when parent default is set', async () => {
+        const definition = cloneDeep(componentsDefinition);
+        definition.componentProperties[0].defaultValue = '_option1';
+        definition.componentProperties[1].defaultValue = '_valueWhenOn';
+        const componentSet = await parseDefinition(definition, getFileContent);
+
+        expect(componentSet.defaultComponentContent).toEqual({
+            body: { data: { conditionalProperty: 'value1' }, styles: { checkboxProperty: '_valueWhenOn' } },
+        });
+    });
+
+    it('should add default content of default child property when parent has no default', async () => {
+        const definition = cloneDeep(componentsDefinition);
+        definition.componentProperties[0].defaultValue = '_option1';
+        definition.componentProperties[1].defaultValue = '_valueWhenOn';
+        // Removing the defaultValue will match with the first option in the select which has no value
+        delete definition.componentProperties[2].defaultValue;
+        const componentSet = await parseDefinition(definition, getFileContent);
+
+        expect(componentSet.defaultComponentContent).toEqual({
+            body: { data: { selectProperty: '_option1' } },
+        });
+    });
 });

--- a/test/parser/parser-util.child-properties.test.ts
+++ b/test/parser/parser-util.child-properties.test.ts
@@ -254,7 +254,6 @@ describe('Parser utils child properties', () => {
 
     it('should parse the components definition', async () => {
         const componentSet = await parseDefinition(componentsDefinition, getFileContent);
-        // console.warn(JSON.stringify(componentSet, null, 4));
         expect(componentSet).toEqual(expectedComponentSet);
     });
 

--- a/test/parser/parser-util.child-properties.test.ts
+++ b/test/parser/parser-util.child-properties.test.ts
@@ -1,0 +1,260 @@
+import * as path from 'path';
+import { parseDefinition } from '../../lib/parser';
+import { DirectiveType } from '../../lib/models';
+import cloneDeep = require('lodash.clonedeep');
+
+describe('Parser utils child properties', () => {
+    let componentsDefinition: any;
+    let getFileContent: (filePath: string) => Promise<string>;
+    let html: { [s: string]: string };
+    let expectedComponentSet: any;
+
+    beforeEach(() => {
+        componentsDefinition = {
+            name: 'child properties',
+            description: 'Description',
+            version: '1.0.0',
+            defaultComponentOnEnter: 'body',
+            components: [
+                {
+                    name: 'body',
+                    label: 'Body Label',
+                    icon: 'icons/component.svg',
+                    properties: ['conditionalProperty'],
+                    countStatistics: true,
+                },
+            ],
+            groups: [
+                {
+                    label: 'Minimal',
+                    name: 'minimal',
+                    components: ['body'],
+                },
+            ],
+            componentProperties: [
+                {
+                    name: 'selectProperty',
+                    label: 'Select property sample',
+                    control: {
+                        type: 'select',
+                        options: [
+                            {
+                                caption: 'Default',
+                            },
+                            {
+                                caption: 'Option 1',
+                                value: '_option1',
+                            },
+                        ],
+                    },
+                    dataType: 'data',
+                },
+                {
+                    name: 'checkboxProperty',
+                    label: 'Checkbox property sample',
+                    control: {
+                        type: 'checkbox',
+                        value: '_valueWhenOn',
+                    },
+                    dataType: 'styles',
+                },
+                {
+                    name: 'conditionalProperty',
+                    label: 'Conditional property sample',
+                    control: {
+                        type: 'select',
+                        options: [
+                            {
+                                caption: 'No value',
+                            },
+                            {
+                                caption: 'Value 1',
+                                value: 'value1',
+                            },
+                            {
+                                caption: 'Value 2',
+                                value: 'value2',
+                            },
+                            {
+                                caption: 'Value 3',
+                                value: 'value3',
+                            },
+                        ],
+                    },
+                    defaultValue: 'value1',
+                    dataType: 'data',
+                    childProperties: [
+                        {
+                            matchType: 'exact-value',
+                            properties: ['selectProperty'],
+                        },
+                        {
+                            matchType: 'exact-value',
+                            matchExpression: 'value1',
+                            properties: ['checkboxProperty'],
+                        },
+                        {
+                            matchType: 'exact-value',
+                            matchExpression: 'value2',
+                            properties: ['selectProperty', 'checkboxProperty'],
+                        },
+                    ],
+                },
+            ],
+            conversionRules: {},
+            shortcuts: {},
+        };
+        html = {
+            body: `<p doc-editable="text"></p>`,
+        };
+        getFileContent = (filePath: string): Promise<string> => {
+            const filename = path.basename(filePath).split('.').shift();
+            if (!filename || !(filename in html)) {
+                throw new Error(`Unknown filename "${filename}", cannot be handled`);
+            }
+            return Promise.resolve(html[filename]);
+        };
+        expectedComponentSet = {
+            name: 'child properties',
+            description: 'Description',
+            version: '1.0.0',
+            components: {
+                body: {
+                    name: 'body',
+                    label: 'Body Label',
+                    icon: 'icons/component.svg',
+                    countStatistics: true,
+                    directives: {
+                        text: {
+                            type: DirectiveType.editable,
+                            tag: 'p',
+                        },
+                    },
+                    properties: [
+                        {
+                            name: 'conditionalProperty',
+                            label: 'Conditional property sample',
+                            control: {
+                                type: 'select',
+                                options: [
+                                    {
+                                        caption: 'No value',
+                                    },
+                                    {
+                                        caption: 'Value 1',
+                                        value: 'value1',
+                                    },
+                                    {
+                                        caption: 'Value 2',
+                                        value: 'value2',
+                                    },
+                                    {
+                                        caption: 'Value 3',
+                                        value: 'value3',
+                                    },
+                                ],
+                            },
+                            defaultValue: 'value1',
+                            dataType: 'data',
+                            childProperties: [
+                                {
+                                    matchType: 'exact-value',
+                                    properties: [
+                                        {
+                                            name: 'selectProperty',
+                                            label: 'Select property sample',
+                                            control: {
+                                                type: 'select',
+                                                options: [
+                                                    {
+                                                        caption: 'Default',
+                                                    },
+                                                    {
+                                                        caption: 'Option 1',
+                                                        value: '_option1',
+                                                    },
+                                                ],
+                                            },
+                                            dataType: 'data',
+                                        },
+                                    ],
+                                },
+                                {
+                                    matchType: 'exact-value',
+                                    matchExpression: 'value1',
+                                    properties: [
+                                        {
+                                            name: 'checkboxProperty',
+                                            label: 'Checkbox property sample',
+                                            control: {
+                                                type: 'checkbox',
+                                                value: '_valueWhenOn',
+                                            },
+                                            dataType: 'styles',
+                                        },
+                                    ],
+                                },
+                                {
+                                    matchType: 'exact-value',
+                                    matchExpression: 'value2',
+                                    properties: [
+                                        {
+                                            name: 'selectProperty',
+                                            label: 'Select property sample',
+                                            control: {
+                                                type: 'select',
+                                                options: [
+                                                    {
+                                                        caption: 'Default',
+                                                    },
+                                                    {
+                                                        caption: 'Option 1',
+                                                        value: '_option1',
+                                                    },
+                                                ],
+                                            },
+                                            dataType: 'data',
+                                        },
+                                        {
+                                            name: 'checkboxProperty',
+                                            label: 'Checkbox property sample',
+                                            control: {
+                                                type: 'checkbox',
+                                                value: '_valueWhenOn',
+                                            },
+                                            dataType: 'styles',
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    renditions: {
+                        html: html.body,
+                    },
+                    noCreatePermission: false,
+                },
+            },
+            groups: [
+                {
+                    label: 'Minimal',
+                    name: 'minimal',
+                    components: ['body'],
+                },
+            ],
+            defaultComponentOnEnter: 'body',
+            defaultComponentContent: {
+                body: { data: { conditionalProperty: 'value1' } },
+            },
+            conversionRules: {},
+            scripts: [],
+            shortcuts: {},
+        };
+    });
+
+    it('should parse the components definition', async () => {
+        const componentSet = await parseDefinition(componentsDefinition, getFileContent);
+        // console.warn(JSON.stringify(componentSet, null, 4));
+        expect(componentSet).toEqual(expectedComponentSet);
+    });
+});

--- a/test/resources/minimal-sample-next/components-definition.json
+++ b/test/resources/minimal-sample-next/components-definition.json
@@ -9,7 +9,7 @@
             "name": "body",
             "label": "Body Label",
             "icon": "icons/component.svg",
-            "properties": ["selectProperty"],
+            "properties": ["selectProperty", "conditionalProperty"],
             "countStatistics": true
         },
         {
@@ -96,6 +96,47 @@
             },
             "defaultValue": -2,
             "dataType": "data"
+        },
+        {
+            "name": "conditionalProperty",
+            "label": "Conditional property sample",
+            "control": {
+                "type": "select",
+                "options": [
+                    {
+                        "caption": "No value"
+                    },
+                    {
+                        "caption": "Value 1",
+                        "value": "value1"
+                    },
+                    {
+                        "caption": "Value 2",
+                        "value": "value2"
+                    },
+                    {
+                        "caption": "Value 3",
+                        "value": "value3"
+                    }
+                ]
+            },
+            "dataType": "data",
+            "childProperties": [
+                {
+                    "matchType": "exact-value",
+                    "properties": ["selectProperty"]
+                },
+                {
+                    "matchType": "exact-value",
+                    "matchExpression": "value1",
+                    "properties": ["checkboxProperty"]
+                },
+                {
+                    "matchType": "exact-value",
+                    "matchExpression": "value2",
+                    "properties": [{ "name": "header", "label": "Label" }, "selectProperty", "sliderProperty"]
+                }
+            ]
         }
     ],
 

--- a/test/resources/minimal-sample-next/components-definition.json
+++ b/test/resources/minimal-sample-next/components-definition.json
@@ -77,6 +77,27 @@
             "dataType": "styles"
         },
         {
+            "name": "childSelectProperty",
+            "label": "Select property sample",
+            "control": {
+                "type": "select",
+                "options": [
+                    {
+                        "caption": "Default"
+                    },
+                    {
+                        "caption": "Option 1",
+                        "value": "_option1"
+                    },
+                    {
+                        "caption": "Option 2",
+                        "value": "_option2"
+                    }
+                ]
+            },
+            "dataType": "styles"
+        },
+        {
             "name": "checkboxProperty",
             "label": "Checkbox property sample",
             "control": {
@@ -124,7 +145,7 @@
             "childProperties": [
                 {
                     "matchType": "exact-value",
-                    "properties": ["selectProperty"]
+                    "properties": ["childSelectProperty"]
                 },
                 {
                     "matchType": "exact-value",
@@ -134,7 +155,11 @@
                 {
                     "matchType": "exact-value",
                     "matchExpression": "value2",
-                    "properties": [{ "name": "header", "label": "Label" }, "selectProperty", "sliderProperty"]
+                    "properties": [
+                        { "control": { "type": "header" }, "label": "Label" },
+                        "childSelectProperty",
+                        "sliderProperty"
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
* Parses the child properties and builds the default component content when child properties are set.
* Adds JSON schema typing

Does not validate that child property names are unique for the component yet.