### PR TITLE
Restrict inline properties

### DIFF
--- a/lib/components-schema-v1_7_x.ts
+++ b/lib/components-schema-v1_7_x.ts
@@ -8,6 +8,11 @@
 
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
+const defaultValue: JSONSchema7Definition = {
+    type: ['integer', 'string', 'number', 'object'],
+    description: 'Default value of property upon component creation. By default the property value is not defined.',
+};
+
 function labelProperty(description: string): { oneOf: JSONSchema7Definition[] } {
     return {
         oneOf: [
@@ -43,7 +48,7 @@ const inlineComponentPropertyDefinitionOrReferenceList: { oneOf: JSONSchema7Defi
         {
             type: 'object',
             additionalProperties: false,
-            required: ['name', 'directiveKey'],
+            anyOf: [{ required: ['name', 'directiveKey'] }, { required: ['name', 'defaultValue'] }],
             properties: {
                 name: {
                     type: 'string',
@@ -54,6 +59,7 @@ const inlineComponentPropertyDefinitionOrReferenceList: { oneOf: JSONSchema7Defi
                     type: 'string',
                     description: 'Directive key for properties that use a directive data type',
                 },
+                defaultValue: defaultValue,
             },
         },
         {
@@ -418,20 +424,7 @@ const componentPropertyDefinition: {
         description:
             'Type of data being stored and how it is used. For directive data types it may also depend on the control type.',
     },
-    defaultValue: {
-        description: 'Default value of property upon component creation. By default the property value is not defined.',
-        oneOf: [
-            {
-                type: 'string',
-            },
-            {
-                type: 'object',
-            },
-            {
-                type: 'number',
-            },
-        ],
-    },
+    defaultValue: defaultValue,
     group: { type: 'string' },
     selector: {
         type: 'string',

--- a/lib/components-schema-v1_7_x.ts
+++ b/lib/components-schema-v1_7_x.ts
@@ -47,7 +47,7 @@ const inlineComponentPropertyDefinitionOrReferenceList: { oneOf: JSONSchema7Defi
             properties: {
                 name: {
                     type: 'string',
-                    description: 'component property identifier',
+                    description: 'Component property identifier',
                     minLength: 3,
                 },
                 directiveKey: {
@@ -449,17 +449,17 @@ const componentPropertyDefinition: {
             properties: {
                 matchType: {
                     type: 'string',
-                    description: `Defines how to match the parent property's value`,
+                    description: `Defines how to match the value of the parent property`,
                     enum: ['exact-value'],
                 },
                 matchExpression: {
                     type: ['boolean', 'integer', 'string', 'number'],
-                    description: `The expression to use to match the parent property's value`,
+                    description: `The expression to use to match the value of the parent property`,
                 },
                 properties: {
                     type: 'array',
                     items: inlineComponentPropertyDefinitionOrReferenceList,
-                    description: 'names of properties this component can use',
+                    description: 'Names of properties this component can use',
                 },
             },
             additionalProperties: false,
@@ -507,7 +507,7 @@ export const componentsDefinitionSchema_v1_7_x: JSONSchema7 = {
                     properties: {
                         type: 'array',
                         items: inlineComponentPropertyDefinitionOrReferenceList,
-                        description: 'names of properties this component can use',
+                        description: 'Names of properties this component can use',
                     },
 
                     selectionMethod: {

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -71,6 +71,11 @@ export class PropertiesValidator extends Validator {
                 `Property in component "${component.name}" must have a name when using control type "${property.control.type}"`,
             );
         }
+        if (property.dataType) {
+            this.error(
+                `Nameless property with control type "${property.control.type}" and label "${property.label}" in component "${component.name}" cannot have a dataType`,
+            );
+        }
     }
 
     private validateRadioPropertyIcons(property: ComponentProperty) {

--- a/test/resources/minimal-sample-next/components-definition.json
+++ b/test/resources/minimal-sample-next/components-definition.json
@@ -157,6 +157,9 @@
                     "matchExpression": "value2",
                     "properties": [
                         { "control": { "type": "header" }, "label": "Label" },
+                        { "name": "sliderProperty", "defaultValue": 2 },
+                        { "name": "sliderProperty", "directiveKey": "text" },
+                        { "name": "sliderProperty", "defaultValue": 2, "directiveKey": "text" },
                         "childSelectProperty",
                         "sliderProperty"
                     ]

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -33,6 +33,12 @@ describe('PropertiesValidator', () => {
                             },
                             dataType: 'doc-media',
                         },
+                        {
+                            control: {
+                                type: 'header',
+                            },
+                            label: 'header-label',
+                        },
                     ],
                 },
                 // Add another component with same property to test uniqueness validation passes correctly
@@ -104,6 +110,13 @@ describe('PropertiesValidator', () => {
             );
             expect(error).toHaveBeenCalledWith(
                 `Property in component "c1" must have a name when using control type "media-properties"`,
+            );
+        });
+        it('should not pass if a header has a dataType', () => {
+            definition.components.c1.properties[3].dataType = 'data';
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(
+                `Nameless property with control type "header" and label "header-label" in component "c1" cannot have a dataType`,
             );
         });
     });


### PR DESCRIPTION
Restricts the inline properties in the component's properties array to just inline header property definitions and references to existing component properties overriding the directive key.
```
{ control: { type: 'header' }, label: 'Header Label' },
```
```
{ "name": "hyperlink", "directiveKey": "hyperlink" }
```

Adds validation that verifies that parsed header properties have no dataType property