### PR TITLE
ECS-392: Disallow child properties to have a default value

### DIFF
--- a/lib/components-schema-v1_7_x.ts
+++ b/lib/components-schema-v1_7_x.ts
@@ -40,48 +40,54 @@ function labelProperty(description: string): { oneOf: JSONSchema7Definition[] } 
     };
 }
 
-const inlineComponentPropertyDefinitionOrReferenceList: { oneOf: JSONSchema7Definition[] } = {
-    oneOf: [
-        {
-            type: 'string',
-        },
-        {
-            type: 'object',
-            additionalProperties: false,
-            anyOf: [{ required: ['name', 'directiveKey'] }, { required: ['name', 'defaultValue'] }],
-            properties: {
-                name: {
-                    type: 'string',
-                    description: 'Component property identifier',
-                    minLength: 3,
-                },
-                directiveKey: {
-                    type: 'string',
-                    description: 'Directive key for properties that use a directive data type',
-                },
-                defaultValue: defaultValue,
+function inlineComponentPropertyDefinitionOrReferenceList(
+    isChildProperty: boolean,
+): { oneOf: JSONSchema7Definition[] } {
+    return {
+        oneOf: [
+            {
+                type: 'string',
             },
-        },
-        {
-            type: 'object',
-            additionalProperties: false,
-            required: ['control', 'label'],
-            properties: {
-                control: {
-                    type: 'object',
-                    additionalProperties: false,
-                    required: ['type'],
-                    properties: {
-                        type: {
-                            enum: ['header'],
+            {
+                type: 'object',
+                additionalProperties: false,
+                anyOf: [{ required: ['name', 'directiveKey'] }].concat(
+                    !isChildProperty ? [{ required: ['name', 'defaultValue'] }] : [],
+                ),
+                properties: {
+                    name: {
+                        type: 'string',
+                        description: 'Component property identifier',
+                        minLength: 3,
+                    },
+                    directiveKey: {
+                        type: 'string',
+                        description: 'Directive key for properties that use a directive data type',
+                    },
+                    defaultValue: defaultValue,
+                },
+            },
+            {
+                type: 'object',
+                additionalProperties: false,
+                required: ['control', 'label'],
+                properties: {
+                    control: {
+                        type: 'object',
+                        additionalProperties: false,
+                        required: ['type'],
+                        properties: {
+                            type: {
+                                enum: ['header'],
+                            },
                         },
                     },
+                    label: labelProperty('Header label'),
                 },
-                label: labelProperty('Header label'),
             },
-        },
-    ],
-};
+        ],
+    };
+}
 
 const componentGroupDefinition: JSONSchema7Definition = {
     type: 'array',
@@ -451,7 +457,7 @@ const componentPropertyDefinition: {
                 },
                 properties: {
                     type: 'array',
-                    items: inlineComponentPropertyDefinitionOrReferenceList,
+                    items: inlineComponentPropertyDefinitionOrReferenceList(true),
                     description: 'Names of properties this component can use',
                 },
             },
@@ -499,7 +505,7 @@ export const componentsDefinitionSchema_v1_7_x: JSONSchema7 = {
                     icon: { type: 'string', description: 'Icon shown for component in Digital Editor' },
                     properties: {
                         type: 'array',
-                        items: inlineComponentPropertyDefinitionOrReferenceList,
+                        items: inlineComponentPropertyDefinitionOrReferenceList(false),
                         description: 'Names of properties this component can use',
                     },
 

--- a/test/resources/minimal-sample-next/components-definition.json
+++ b/test/resources/minimal-sample-next/components-definition.json
@@ -119,30 +119,6 @@
             "dataType": "data"
         },
         {
-            "name": "sliderProperty2",
-            "label": "Slider property sample 2",
-            "control": {
-                "type": "slider",
-                "minValue": -4,
-                "maxValue": 5,
-                "stepSize": 0.5
-            },
-            "defaultValue": -2,
-            "dataType": "data"
-        },
-        {
-            "name": "sliderProperty3",
-            "label": "Slider property sample 3",
-            "control": {
-                "type": "slider",
-                "minValue": -4,
-                "maxValue": 5,
-                "stepSize": 0.5
-            },
-            "defaultValue": -2,
-            "dataType": "data"
-        },
-        {
             "name": "conditionalProperty",
             "label": "Conditional property sample",
             "control": {
@@ -181,9 +157,7 @@
                     "matchExpression": "value2",
                     "properties": [
                         { "control": { "type": "header" }, "label": "Label" },
-                        { "name": "sliderProperty", "defaultValue": 2 },
-                        { "name": "sliderProperty2", "directiveKey": "text" },
-                        { "name": "sliderProperty3", "defaultValue": 2, "directiveKey": "text" },
+                        { "name": "sliderProperty", "directiveKey": "text" },
                         "childSelectProperty",
                         "checkboxProperty"
                     ]


### PR DESCRIPTION
Only on the top level allow default values to prevent problems in the editor. Alternatively we can support to editor for having (different) default values in child properties, but let's wait till that is requested.