### PR TITLE
ECS-408: Allow boolean values for checkbox property

### DIFF
--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -111,7 +111,9 @@ export class PropertiesValidator extends Validator {
             return;
         }
         if (typeof property.control.value === 'boolean' && property.dataType !== 'data') {
-            this.error(`Checkbox property with boolean value can only be used with dataType "data"`);
+            this.error(
+                `Checkbox property "${property.name}" cannot have a boolean value for dataType "${property.dataType}", boolean values are only allowed for dataType "data"`,
+            );
         }
     }
 

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -52,6 +52,7 @@ export class PropertiesValidator extends Validator {
         this.validateReservedPropertyName(property);
         this.validatePropertyName(property, componentPropertyNames, component);
         this.validateRadioPropertyIcons(property);
+        this.validateCheckBoxValue(property);
     }
 
     private validatePropertyName(
@@ -102,6 +103,15 @@ export class PropertiesValidator extends Validator {
             if (!this.filePaths.has(path.normalize(controlOption.icon))) {
                 this.error(`Component properties "${property.name}" icon missing "${controlOption.icon}"`);
             }
+        }
+    }
+
+    private validateCheckBoxValue(property: ComponentProperty) {
+        if (property.control.type !== 'checkbox') {
+            return;
+        }
+        if (typeof property.control.value === 'boolean' && property.dataType !== 'data') {
+            this.error(`Checkbox property with boolean value can only be used with dataType "data"`);
         }
     }
 

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -29,6 +29,13 @@ describe('PropertiesValidator', () => {
         },
         label: 'header-label',
     } as any;
+    const checkboxProperty: ComponentProperty = {
+        name: 'checkboxProperty',
+        control: {
+            type: 'checkbox',
+            value: true,
+        },
+    } as any;
 
     function createConditionalProperty(children: any[]) {
         return {
@@ -283,6 +290,30 @@ describe('PropertiesValidator', () => {
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
                 `Property in component "c1" with control type "fitting" cannot contain child properties`,
+            );
+        });
+
+        it('should pass if checkbox property with "data" dataType is used with boolean value', () => {
+            const prop = cloneDeep(checkboxProperty);
+            prop.dataType = 'data';
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.7.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should fail if checkbox property with non "data" dataType is used with boolean value', () => {
+            const prop = cloneDeep(checkboxProperty);
+            prop.dataType = 'styles';
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.7.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).toHaveBeenCalledWith(
+                `Checkbox property with boolean value can only be used for dataType "data"`,
             );
         });
     });

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -293,7 +293,7 @@ describe('PropertiesValidator', () => {
             );
         });
 
-        it('should pass if checkbox property with "data" dataType is used with boolean value', () => {
+        it('should pass if a checkbox with dataType "data" is used with a boolean value', () => {
             const prop = cloneDeep(checkboxProperty);
             prop.dataType = 'data';
             const { validator, errorSpy } = createPropertiesValidator({
@@ -304,7 +304,7 @@ describe('PropertiesValidator', () => {
             expect(errorSpy).not.toHaveBeenCalled();
         });
 
-        it('should fail if checkbox property with non "data" dataType is used with boolean value', () => {
+        it('should not pass if a checkbox with dataType other than "data" is used with a boolean value', () => {
             const prop = cloneDeep(checkboxProperty);
             prop.dataType = 'styles';
             const { validator, errorSpy } = createPropertiesValidator({
@@ -313,7 +313,7 @@ describe('PropertiesValidator', () => {
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
-                `Checkbox property with boolean value can only be used with dataType "data"`,
+                `Checkbox property "checkboxProperty" cannot have a boolean value for dataType "styles", boolean values are only allowed for dataType "data"`,
             );
         });
     });

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -313,7 +313,7 @@ describe('PropertiesValidator', () => {
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
-                `Checkbox property with boolean value can only be used for dataType "data"`,
+                `Checkbox property with boolean value can only be used with dataType "data"`,
             );
         });
     });


### PR DESCRIPTION
Boolean values can be safely used when dataType equals "data" as they are not used in css. This change allows cleaner definition of the checkboxes we need in the Apple News component set.