### PR TITLE
CSH-8382: remove path.normalise in parser util.

### DIFF
--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -2,7 +2,6 @@
  * Utils which parse components definition
  */
 
-import * as path from 'path';
 import * as htmlparser from 'htmlparser2';
 import {
     Component,
@@ -132,10 +131,9 @@ async function loadRendition(
     if (!component.renditions) {
         component.renditions = {};
     }
-    component.renditions[rendition] = (await getFileContent(
-        path.normalize(`./templates/${rendition}/${component.name}.html`),
-        { encoding: 'utf8' },
-    )) as string;
+    component.renditions[rendition] = (await getFileContent(`./templates/${rendition}/${component.name}.html`, {
+        encoding: 'utf8',
+    })) as string;
     return component;
 }
 


### PR DESCRIPTION
The getFileContent function can take care of normalising the path if it wants.
By not calling path here, we should not need to include a path polyfill in our code.