### PR TITLE
Bump validator version to 1.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Validation module for Studio Digital Editor component sets.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Patch release since no new functionality.