### PR TITLE
Bump validator version to 1.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Validation module for Studio Digital Editor component sets.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Patch since it fixes just a missing type.