### PR TITLE
scout: tighten ts code checking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
     plugins: ['@typescript-eslint'],
     extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier', 'plugin:prettier/recommended'],
     rules: {
-        '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
         'object-shorthand': ['error', 'never'],
     },
     overrides: [

--- a/lib/validators/package-validator.ts
+++ b/lib/validators/package-validator.ts
@@ -90,7 +90,7 @@ export class PackageValidator extends Validator {
     }
 }
 
-export function validateTotalSize(size: number): string | undefined {
+export function validateTotalSize(size: number): string | void {
     const sizeMB = Math.round(size / MB_IN_BYTES);
     if (sizeMB > MAX_COMPONENT_SET_SIZE_MB) {
         return `At ${sizeMB}MB, the component set exceeds the total maximum size of ${MAX_COMPONENT_SET_SIZE_MB}MB.`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,13 @@
         "outDir": "./dist",
         "strict": true,
         "lib": ["es2015", "es2017.object", "es2016.array.include"],
-        "typeRoots": ["./node_modules/@types", "./types"]
+        "typeRoots": ["./node_modules/@types", "./types"],
+        "noUnusedParameters": true,
+        "noUnusedLocals": true,
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
     },
     "include": ["./lib/**/*"]
 }


### PR DESCRIPTION
Noticed warnings about unused imports in the IDE. Turns them into errors through TS.