### PR TITLE
CSH-8382: roll back 523b8ba and solve in a different way

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ The validation result is returned as a boolean value and any error is logged to 
 
 ### `validate`
 
-Lower level method that validates the component set given a set of paths, a function to get the file content given the path and a function that logs errors. This api is useful when the component set is validated in memory.
+Lower level method that validates the component set given a set of normalized relative paths, a function to get the file content given the normalized relative path and a function that logs errors. This api is useful when the component set is validated in memory.
 
 ```ts
 import { validate } from './lib/validate';
 
 const filePaths = new Set(['path1', 'path2']);
-const getFileContent = async (filePath: string) => 'fileContent';
+const getFileContent = async (normalizedRelativefilePath: string) => 'fileContent';
 const errorReporter = (errorMessage: string) => console.error(errorMessage);
 
 const validationResult: boolean = await validate(filePaths, getFileContent, errorReporter);
@@ -50,11 +50,6 @@ const validationResult: boolean = await validatePackageSize(packageSize, errorRe
 ```
 
 ### `parseDefinition`
-
-If published version (from "dist" folder) of the package is used then:
-
--   if parser is going to be used in the browser remember that package's target is ES6 which may be unsupported or partly supported by the browsers
--   also polyfills may be needed for IE browsers
 
 An example of possible usage:
 

--- a/lib/models/get-file-content.ts
+++ b/lib/models/get-file-content.ts
@@ -6,9 +6,12 @@ export type GetFileContentOptionsType = { encoding: string | null } | null;
 /**
  * Return string if encoding is string and Buffer otherwise.
  */
-export type GetFileContentType = (filePath: string, options?: GetFileContentOptionsType) => Promise<string | Buffer>;
+export type GetFileContentType = (
+    normalizedRelativeFilePath: string,
+    options?: GetFileContentOptionsType,
+) => Promise<string | Buffer>;
 
 /**
  * Return file size in bytes.
  */
-export type GetFileSize = (filePath: string) => Promise<number>;
+export type GetFileSize = (normalizedRelativeFilePath: string) => Promise<number>;

--- a/lib/renditions/index.ts
+++ b/lib/renditions/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/lib/renditions/utils.ts
+++ b/lib/renditions/utils.ts
@@ -1,13 +1,13 @@
 import * as path from 'path';
 import { Component, ComponentRendition, ComponentsDefinition, GetFileContentType } from '../models';
-import merge = require('lodash.merge');
+import cloneDeep = require('lodash.clonedeep');
 import { deepFreeze } from '../util/freeze';
 
 export async function loadHtmlRenditions(
     componentsDefinition: ComponentsDefinition,
     getFileContent: GetFileContentType,
 ): Promise<ComponentsDefinition> {
-    const enrichedDefinition = merge({}, componentsDefinition);
+    const enrichedDefinition = cloneDeep(componentsDefinition);
     for (const compDef of enrichedDefinition.components) {
         if (!hasRendition(compDef, ComponentRendition.HTML)) {
             await loadRendition(compDef, ComponentRendition.HTML, getFileContent);

--- a/lib/renditions/utils.ts
+++ b/lib/renditions/utils.ts
@@ -3,7 +3,7 @@ import { Component, ComponentRendition, ComponentsDefinition, GetFileContentType
 import merge = require('lodash.merge');
 import { deepFreeze } from '../util/freeze';
 
-export async function loadRenditions(
+export async function loadHtmlRenditions(
     componentsDefinition: ComponentsDefinition,
     getFileContent: GetFileContentType,
 ): Promise<ComponentsDefinition> {

--- a/lib/renditions/utils.ts
+++ b/lib/renditions/utils.ts
@@ -29,7 +29,7 @@ async function loadRendition(
         component.renditions = {};
     }
     component.renditions[rendition] = (await getFileContent(
-        path.normalize(`./templates/${rendition}/${component.name}.html`),
+        path.normalize(`templates/${rendition}/${component.name}.html`),
         {
             encoding: 'utf8',
         },

--- a/lib/renditions/utils.ts
+++ b/lib/renditions/utils.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+import { Component, ComponentRendition, ComponentsDefinition, GetFileContentType } from '../models';
+import merge = require('lodash.merge');
+import { deepFreeze } from '../util/freeze';
+
+export async function loadRenditions(
+    componentsDefinition: ComponentsDefinition,
+    getFileContent: GetFileContentType,
+): Promise<ComponentsDefinition> {
+    const enrichedDefinition = merge({}, componentsDefinition);
+    for (const compDef of enrichedDefinition.components) {
+        if (!hasRendition(compDef, ComponentRendition.HTML)) {
+            await loadRendition(compDef, ComponentRendition.HTML, getFileContent);
+        }
+    }
+    return deepFreeze(enrichedDefinition);
+}
+
+function hasRendition(component: Component, rendition: ComponentRendition): boolean {
+    return Boolean(component.renditions && rendition in component.renditions);
+}
+
+async function loadRendition(
+    component: Component,
+    rendition: ComponentRendition,
+    getFileContent: GetFileContentType,
+): Promise<Component> {
+    if (!component.renditions) {
+        component.renditions = {};
+    }
+    component.renditions[rendition] = (await getFileContent(
+        path.normalize(`./templates/${rendition}/${component.name}.html`),
+        {
+            encoding: 'utf8',
+        },
+    )) as string;
+    return component;
+}

--- a/lib/util/freeze.ts
+++ b/lib/util/freeze.ts
@@ -1,0 +1,21 @@
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
+ */
+export function deepFreeze<T>(object: T): T {
+    // Retrieve the property names defined on object
+    const propNames = Object.getOwnPropertyNames(object);
+
+    // Freeze properties before freezing self
+
+    for (const name of propNames) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const value = object[name];
+
+        if (value && typeof value === 'object') {
+            deepFreeze(value as T);
+        }
+    }
+
+    return Object.freeze(object);
+}

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -60,7 +60,7 @@ import {
     Validator,
 } from './validators';
 import { listFilesRelativeToFolder } from './util/files';
-import { loadRenditions } from './renditions';
+import { loadHtmlRenditions } from './renditions';
 import { deepFreeze } from './util/freeze';
 
 const ajvInstance = new ajv({ allErrors: true, verbose: true, allowUnionTypes: true });
@@ -169,7 +169,7 @@ export async function validate(
     // parse everything for deeper testing
     let componentSet: ComponentSet | null = null;
     try {
-        componentSet = await parseDefinition(await loadRenditions(componentsDefinition, getFileContent));
+        componentSet = await parseDefinition(await loadHtmlRenditions(componentsDefinition, getFileContent));
     } catch (e) {
         errorReporter(e.message ?? e);
     }

--- a/lib/validators/components-validator.ts
+++ b/lib/validators/components-validator.ts
@@ -13,9 +13,9 @@ import { ComponentSet } from '../models';
 
 const RESERVED = [/^__internal__/];
 const GENERIC_FILES = [
-    path.normalize('./styles/_common.scss'),
-    path.normalize('./styles/design.scss'),
-    path.normalize('./styles/design.css'),
+    path.normalize('styles/_common.scss'),
+    path.normalize('styles/design.scss'),
+    path.normalize('styles/design.css'),
 ];
 
 export class ComponentsValidator extends Validator {
@@ -43,13 +43,13 @@ export class ComponentsValidator extends Validator {
             }
 
             // Validate the component has a html template
-            const htmlTemplatePath = path.normalize(`./templates/html/${comp.name}.html`);
+            const htmlTemplatePath = path.normalize(`templates/html/${comp.name}.html`);
             if (!this.filePaths.has(htmlTemplatePath)) {
                 this.error(`Component "${comp.name}" html template missing "${htmlTemplatePath}"`);
             }
 
             // Validate the component has a style
-            const componentStylePath = path.normalize(`./styles/_${comp.name}.scss`);
+            const componentStylePath = path.normalize(`styles/_${comp.name}.scss`);
             if (!this.filePaths.has(componentStylePath)) {
                 this.error(`Component "${comp.name}" style scss file missing "${componentStylePath}"`);
             }

--- a/test/parser/parser-util.child-properties.test.ts
+++ b/test/parser/parser-util.child-properties.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { parseDefinition } from '../../lib/parser';
 import { ComponentsDefinition, DirectiveType } from '../../lib/models';
-import { loadRenditions } from '../../lib/renditions';
+import { loadHtmlRenditions } from '../../lib/renditions';
 import { deepFreeze } from '../../lib/util/freeze';
 
 describe('Parser utils child properties', () => {
@@ -261,13 +261,15 @@ describe('Parser utils child properties', () => {
     });
 
     it('should parse the components definition', async () => {
-        const componentSet = await parseDefinition(await loadRenditions(createComponentsDefinition(), getFileContent));
+        const componentSet = await parseDefinition(
+            await loadHtmlRenditions(createComponentsDefinition(), getFileContent),
+        );
         expect(componentSet).toEqual(expectedComponentSet);
     });
 
     it('should add default content of default child property when parent default is set', async () => {
         const componentSet = await parseDefinition(
-            await loadRenditions(
+            await loadHtmlRenditions(
                 createComponentsDefinition((definition) => {
                     definition.componentProperties[0].defaultValue = '_option1';
                     definition.componentProperties[1].defaultValue = '_valueWhenOn';
@@ -283,7 +285,7 @@ describe('Parser utils child properties', () => {
 
     it('should add default content of default child property when parent has no default', async () => {
         const componentSet = await parseDefinition(
-            await loadRenditions(
+            await loadHtmlRenditions(
                 createComponentsDefinition((definition) => {
                     definition.componentProperties[0].defaultValue = '_option1';
                     definition.componentProperties[1].defaultValue = '_valueWhenOn';

--- a/test/parser/parser-util.child-properties.test.ts
+++ b/test/parser/parser-util.child-properties.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import { parseDefinition } from '../../lib/parser';
 import { ComponentsDefinition, DirectiveType } from '../../lib/models';
-import cloneDeep = require('lodash.clonedeep');
 import { loadRenditions } from '../../lib/renditions';
 import { deepFreeze } from '../../lib/util/freeze';
 

--- a/test/parser/parser-util.test.ts
+++ b/test/parser/parser-util.test.ts
@@ -1,15 +1,17 @@
 import * as path from 'path';
 import { parseDefinition } from '../../lib/parser/parser-utils';
-import { DirectiveType, ComponentRendition } from '../../lib/models';
+import { DirectiveType, ComponentRendition, ComponentsDefinition } from '../../lib/models';
 import cloneDeep = require('lodash.clonedeep');
+import { loadRenditions } from '../../lib/renditions';
+import { deepFreeze } from '../../lib/util/freeze';
 
 describe('Parser utils', () => {
     describe('parseDefinition', () => {
-        let componentsDefinition: any;
         let getFileContent: (filePath: string) => Promise<string>;
         let html: { [s: string]: string };
-        beforeEach(() => {
-            componentsDefinition = {
+
+        function createComponentsDefinition(init?: (componentsDefinition: any) => void): ComponentsDefinition {
+            const definition = {
                 name: 'minimal-sample',
                 description: 'Minimal components package sample touching most of the available options.',
                 version: '1.0.0',
@@ -120,6 +122,12 @@ describe('Parser utils', () => {
                 },
                 shortcuts: { conversionComponents: ['shortcuts'] },
             };
+            if (init) {
+                init(definition);
+            }
+            return deepFreeze(definition as ComponentsDefinition);
+        }
+        beforeEach(() => {
             html = {
                 body: `<p doc-editable="text"></p>`,
                 complex:
@@ -303,34 +311,32 @@ describe('Parser utils', () => {
                 };
             });
             it('should be fine when components definition without renditions', async () => {
-                const componentSet = await parseDefinition(componentsDefinition, getFileContent);
+                const componentSet = await parseDefinition(
+                    await loadRenditions(createComponentsDefinition(), getFileContent),
+                );
                 expect(componentSet).toEqual(expectedComponentSet);
             });
             it('should be fine when components definition with renditions', async () => {
-                componentsDefinition.components[0].renditions = {
-                    [ComponentRendition.HTML]: html.body,
-                };
-                componentsDefinition.components[1].renditions = {
-                    [ComponentRendition.HTML]: html.complex,
-                };
+                const componentsDefinition = createComponentsDefinition((definition) => {
+                    definition.components[0].renditions = {
+                        [ComponentRendition.HTML]: html.body,
+                    };
+                    definition.components[1].renditions = {
+                        [ComponentRendition.HTML]: html.complex,
+                    };
+                });
                 const componentSet = await parseDefinition(componentsDefinition);
                 expect(componentSet).toEqual(expectedComponentSet);
             });
             it('should throw an error when components definition without renditions and getFileContent is not passed', async () => {
                 let er = '';
                 try {
-                    await parseDefinition(componentsDefinition);
+                    await parseDefinition(createComponentsDefinition());
                 } catch (e) {
                     er = e.message;
                 }
                 expect(er).toEqual(`Component "body" doesn't have "html" rendition`);
             });
-        });
-
-        it('should not modify the input components definition', async () => {
-            const originalComponentsDefinition = cloneDeep(componentsDefinition);
-            await parseDefinition(componentsDefinition, getFileContent);
-            expect(componentsDefinition).toEqual(originalComponentsDefinition);
         });
 
         it('should throw an error if there are directives with the same attribute values', async () => {
@@ -347,7 +353,7 @@ describe('Parser utils', () => {
 
             let er = '';
             try {
-                await parseDefinition(componentsDefinition, getFileContent);
+                await parseDefinition(await loadRenditions(createComponentsDefinition(), getFileContent));
             } catch (e) {
                 er = e.message;
             }
@@ -368,7 +374,7 @@ describe('Parser utils', () => {
 
             let er = '';
             try {
-                await parseDefinition(componentsDefinition, getFileContent);
+                await parseDefinition(await loadRenditions(createComponentsDefinition(), getFileContent));
             } catch (e) {
                 er = e.message;
             }
@@ -378,11 +384,16 @@ describe('Parser utils', () => {
         });
 
         it('should throw an error if there is a property which cannot be found', async () => {
-            componentsDefinition.components[0].properties[0] = 'cucicaca';
-
             let er = '';
             try {
-                await parseDefinition(componentsDefinition, getFileContent);
+                await parseDefinition(
+                    await loadRenditions(
+                        createComponentsDefinition((definition) => {
+                            definition.components[0].properties[0] = 'cucicaca';
+                        }),
+                        getFileContent,
+                    ),
+                );
             } catch (e) {
                 er = e.message;
             }
@@ -390,11 +401,16 @@ describe('Parser utils', () => {
         });
 
         it('should throw an error if there is a property which cannot be found for merging', async () => {
-            (<any>componentsDefinition.components[1].properties[1]).name = 'cucicaca';
-
             let er = '';
             try {
-                await parseDefinition(componentsDefinition, getFileContent);
+                await parseDefinition(
+                    await loadRenditions(
+                        createComponentsDefinition((definition) => {
+                            definition.components[1].properties[1].name = 'cucicaca';
+                        }),
+                        getFileContent,
+                    ),
+                );
             } catch (e) {
                 er = e.message;
             }

--- a/test/parser/parser-util.test.ts
+++ b/test/parser/parser-util.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import { parseDefinition } from '../../lib/parser/parser-utils';
 import { DirectiveType, ComponentRendition, ComponentsDefinition } from '../../lib/models';
-import cloneDeep = require('lodash.clonedeep');
 import { loadRenditions } from '../../lib/renditions';
 import { deepFreeze } from '../../lib/util/freeze';
 

--- a/test/parser/parser-util.test.ts
+++ b/test/parser/parser-util.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { parseDefinition } from '../../lib/parser/parser-utils';
-import { DirectiveType, ComponentRendition, ComponentsDefinition } from '../../lib/models';
-import { loadRenditions } from '../../lib/renditions';
+import { ComponentRendition, ComponentsDefinition, DirectiveType } from '../../lib/models';
+import { loadHtmlRenditions } from '../../lib/renditions';
 import { deepFreeze } from '../../lib/util/freeze';
 
 describe('Parser utils', () => {
@@ -311,7 +311,7 @@ describe('Parser utils', () => {
             });
             it('should be fine when components definition without renditions', async () => {
                 const componentSet = await parseDefinition(
-                    await loadRenditions(createComponentsDefinition(), getFileContent),
+                    await loadHtmlRenditions(createComponentsDefinition(), getFileContent),
                 );
                 expect(componentSet).toEqual(expectedComponentSet);
             });
@@ -352,7 +352,7 @@ describe('Parser utils', () => {
 
             let er = '';
             try {
-                await parseDefinition(await loadRenditions(createComponentsDefinition(), getFileContent));
+                await parseDefinition(await loadHtmlRenditions(createComponentsDefinition(), getFileContent));
             } catch (e) {
                 er = e.message;
             }
@@ -373,7 +373,7 @@ describe('Parser utils', () => {
 
             let er = '';
             try {
-                await parseDefinition(await loadRenditions(createComponentsDefinition(), getFileContent));
+                await parseDefinition(await loadHtmlRenditions(createComponentsDefinition(), getFileContent));
             } catch (e) {
                 er = e.message;
             }
@@ -386,7 +386,7 @@ describe('Parser utils', () => {
             let er = '';
             try {
                 await parseDefinition(
-                    await loadRenditions(
+                    await loadHtmlRenditions(
                         createComponentsDefinition((definition) => {
                             definition.components[0].properties[0] = 'cucicaca';
                         }),
@@ -403,7 +403,7 @@ describe('Parser utils', () => {
             let er = '';
             try {
                 await parseDefinition(
-                    await loadRenditions(
+                    await loadHtmlRenditions(
                         createComponentsDefinition((definition) => {
                             definition.components[1].properties[1].name = 'cucicaca';
                         }),


### PR DESCRIPTION
Fixes the problem in ecs backend where the filePaths and getFileContent paths no longer match because one is normalized and the other isn't. Also keeps the getFileContent, getFileSize and filePaths arguments of the validate function consistent: all take normalized paths. The problem of having a path.normalize in the browser is solved by separating the loading of the renditions is a separate function that is not imported in the browser when using parseDefinition. Additionally adds deepFreeze to ensure the components definition is not altered while parsing it into a component set.