### PR TITLE
Ecs 428 publish to GitHub packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,14 @@ jobs:
               with:
                   type: stable
                   token: ${{ secrets.NPM_TOKEN }}
+
+            # https://docs.github.com/en/actions/guides/publishing-nodejs-packages#publishing-packages-to-npm-and-github-packages
+            # Setup .npmrc file to publish to GitHub Packages (can replace the other setup-node action when we no longer publish to npm)
+            - uses: actions/setup-node@v2
+              with:
+                  registry-url: 'https://npm.pkg.github.com'
+                  node-version: 14
+            # Publish to GitHub Packages
+            - run: npm publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Validation module for Studio Digital Editor component sets.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Update workflow action
- Create new patch release to test out publish to GitHub packages.