### PR TITLE
Csh 6552 improve types

### DIFF
--- a/lib/definition/component-info.ts
+++ b/lib/definition/component-info.ts
@@ -1,4 +1,4 @@
-import { ComponentsDefinition, Component, ComponentRendition } from '../models/components-definition';
+import { ComponentsDefinition, ComponentDefinition, ComponentRendition } from '../models/components-definition';
 import { ComponentField, ComponentSetInfo, ComponentInfoFields } from '../models/component-set-info';
 import { RenditionResolver, processTemplates } from './process-templates';
 import parse5 = require('parse5');
@@ -77,7 +77,7 @@ function parseAttributes(componentFields: ComponentField[], attrs?: parse5.Attri
 
 function addRestrictChildrenInfo(
     componentDefinition: ComponentsDefinition,
-    component: Component,
+    component: ComponentDefinition,
     field: ComponentField,
 ): void {
     if (field.type !== 'container') {

--- a/lib/models/component-set.ts
+++ b/lib/models/component-set.ts
@@ -50,7 +50,7 @@ export interface ComponentSet {
      * Map component identifiers to their parsed model.
      */
     components: {
-        [name: string]: ParsedComponent;
+        [name: string]: Component;
     };
 
     /**
@@ -79,7 +79,7 @@ export interface ComponentSet {
     customStyles: CustomStyle[];
 }
 
-export interface ParsedComponent extends ComponentDefinition {
+export interface Component extends ComponentDefinition {
     /**
      * Parsed complete properties of component.
      */

--- a/lib/models/component-set.ts
+++ b/lib/models/component-set.ts
@@ -15,29 +15,19 @@ import {
  * - componentProperties list is removed, as it's merged into the component property lists
  */
 export interface ComponentSet {
-    /**
-     * Name of the components package
-     */
+    /** Name of the components package */
     name: string;
 
-    /**
-     * Description of components package
-     */
+    /** Description of components package */
     description?: string;
 
-    /**
-     * Version of matching components model
-     */
+    /** Version of matching components model */
     version: string;
 
-    /**
-     * Default component inserted on pressing enter in a text field
-     */
+    /** Default component inserted on pressing enter in a text field */
     defaultComponentOnEnter: string;
 
-    /**
-     * Default components content
-     */
+    /** Default components content */
     defaultComponentContent: {
         [componentName: string]: {
             [dataType in ComponentProperty['dataType']]?: {
@@ -46,48 +36,32 @@ export interface ComponentSet {
         };
     };
 
-    /**
-     * Map component identifiers to their parsed model.
-     */
+    /** Map component identifiers to their parsed model. */
     components: {
         [name: string]: Component;
     };
 
-    /**
-     * List of groups shown in component chooser dialog
-     */
+    /** List of groups shown in component chooser dialog */
     groups: ComponentGroup[];
 
-    /**
-     * Conversion rules for transforming one component into another component
-     */
+    /** Conversion rules for transforming one component into another component */
     conversionRules: ComponentConversionRules;
 
-    /**
-     * Shortcuts configurations
-     */
+    /** Shortcuts configurations */
     shortcuts?: ComponentsDefinitionShortcuts;
 
-    /**
-     * List of scripts to be included for html rendition of article
-     */
+    /** List of scripts to be included for html rendition of article */
     scripts: string[];
 
-    /**
-     * List of custom styles definitions which can be configured in the look and feel style of an article
-     */
+    /** List of custom styles definitions which can be configured in the look and feel style of an article */
     customStyles: CustomStyle[];
 }
 
 export interface Component extends ComponentDefinition {
-    /**
-     * Parsed complete properties of component.
-     */
+    /** Parsed complete properties of component. */
     properties: ComponentProperty[];
 
-    /**
-     * Information about directives, added after parsing.
-     */
+    /** Information about directives, added after parsing. */
     directives: {
         [key: string]: {
             type: DirectiveType;
@@ -95,9 +69,7 @@ export interface Component extends ComponentDefinition {
         };
     };
 
-    /**
-     * Flag which forbids creating of the component
-     */
+    /** Flag which forbids creating of the component */
     noCreatePermission: boolean;
 }
 

--- a/lib/models/component-set.ts
+++ b/lib/models/component-set.ts
@@ -1,5 +1,5 @@
 import {
-    Component,
+    ComponentDefinition,
     ComponentProperty,
     ComponentGroup,
     ComponentConversionRules,
@@ -79,7 +79,7 @@ export interface ComponentSet {
     customStyles: CustomStyle[];
 }
 
-export interface ParsedComponent extends Component {
+export interface ParsedComponent extends ComponentDefinition {
     /**
      * Parsed complete properties of component.
      */

--- a/lib/models/components-definition.ts
+++ b/lib/models/components-definition.ts
@@ -22,7 +22,7 @@ export interface ComponentsDefinition {
     defaultComponentOnEnter: string;
 
     /** List of available components */
-    components: Component[];
+    components: ComponentDefinition[];
 
     /** List of available component properties */
     componentProperties: ComponentProperty[];
@@ -43,7 +43,7 @@ export interface ComponentsDefinition {
     customStyles?: CustomStyle[];
 }
 
-export interface Component {
+export interface ComponentDefinition {
     /** Unique component identifier */
     name: string;
 

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -4,7 +4,7 @@
 
 import * as htmlparser from 'htmlparser2';
 import {
-    Component,
+    ComponentDefinition,
     ComponentProperty,
     ComponentRendition,
     ComponentsDefinition,
@@ -100,7 +100,7 @@ function getDirectiveType(directiveName: string): DirectiveType {
  * @param component
  * @param rendition
  */
-function hasRendition(component: Component, rendition: ComponentRendition): boolean {
+function hasRendition(component: ComponentDefinition, rendition: ComponentRendition): boolean {
     return Boolean(component.renditions && rendition in component.renditions);
 }
 
@@ -112,7 +112,7 @@ function hasRendition(component: Component, rendition: ComponentRendition): bool
  * @param rendition
  */
 function parseComponent(
-    component: Component,
+    component: ComponentDefinition,
     componentProperties: ComponentProperty[],
     rendition: ComponentRendition,
 ): ParsedComponent {

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -10,7 +10,7 @@ import {
     ComponentsDefinition,
     ComponentSet,
     DirectiveType,
-    ParsedComponent,
+    Component,
 } from '../models';
 import merge = require('lodash.merge');
 
@@ -115,7 +115,7 @@ function parseComponent(
     component: ComponentDefinition,
     componentProperties: ComponentProperty[],
     rendition: ComponentRendition,
-): ParsedComponent {
+): Component {
     if (!hasRendition(component, rendition)) {
         throw new Error(`Component "${component.name}" doesn't have "${rendition}" rendition`);
     }
@@ -230,7 +230,7 @@ function buildComponentSetDefaultContent(componentSet: ComponentSet): void {
  */
 function buildComponentDefaultContent(
     defaultComponentContent: ComponentSet['defaultComponentContent'],
-    component: ParsedComponent,
+    component: Component,
 ): void {
     for (const property of component.properties) {
         buildComponentPropertyDefaultContent(defaultComponentContent, component.name, property);

--- a/lib/renditions/utils.ts
+++ b/lib/renditions/utils.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { Component, ComponentRendition, ComponentsDefinition, GetFileContentType } from '../models';
+import { ComponentDefinition, ComponentRendition, ComponentsDefinition, GetFileContentType } from '../models';
 import cloneDeep = require('lodash.clonedeep');
 import { deepFreeze } from '../util/freeze';
 
@@ -16,15 +16,15 @@ export async function loadHtmlRenditions(
     return deepFreeze(enrichedDefinition);
 }
 
-function hasRendition(component: Component, rendition: ComponentRendition): boolean {
+function hasRendition(component: ComponentDefinition, rendition: ComponentRendition): boolean {
     return Boolean(component.renditions && rendition in component.renditions);
 }
 
 async function loadRendition(
-    component: Component,
+    component: ComponentDefinition,
     rendition: ComponentRendition,
     getFileContent: GetFileContentType,
-): Promise<Component> {
+): Promise<ComponentDefinition> {
     if (!component.renditions) {
         component.renditions = {};
     }

--- a/lib/validators/autofill-validator.ts
+++ b/lib/validators/autofill-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { DirectiveType, ParsedComponent } from '../models';
+import { DirectiveType, Component } from '../models';
 
 const supportedDestinationDirectives = [DirectiveType.editable, DirectiveType.link];
 const supportedSourceDirectives = [DirectiveType.image];
@@ -25,7 +25,7 @@ export class AutofillValidator extends Validator {
      * @param errorReporter
      * @param parsedComponent
      */
-    validateComponent(parsedComponent: ParsedComponent): void {
+    validateComponent(parsedComponent: Component): void {
         // Only check when it has directiveOptions configured
         if (!parsedComponent.directiveOptions) {
             return;

--- a/lib/validators/autofill-validator.ts
+++ b/lib/validators/autofill-validator.ts
@@ -23,15 +23,15 @@ export class AutofillValidator extends Validator {
      * - destination should not be source
      *
      * @param errorReporter
-     * @param parsedComponent
+     * @param component
      */
-    validateComponent(parsedComponent: Component): void {
+    validateComponent(component: Component): void {
         // Only check when it has directiveOptions configured
-        if (!parsedComponent.directiveOptions) {
+        if (!component.directiveOptions) {
             return;
         }
 
-        for (const [dstKey, directiveOptions] of Object.entries(parsedComponent.directiveOptions)) {
+        for (const [dstKey, directiveOptions] of Object.entries(component.directiveOptions)) {
             // Only for directives with autofill
             if (!directiveOptions.autofill) {
                 continue;
@@ -40,14 +40,14 @@ export class AutofillValidator extends Validator {
             const rule = directiveOptions.autofill;
 
             // check if destination directive exists
-            if (!parsedComponent.directives[dstKey]) {
+            if (!component.directives[dstKey]) {
                 this.error(
-                    `Component "${parsedComponent.name}" has incorrect autofill rule "${dstKey}". ` +
+                    `Component "${component.name}" has incorrect autofill rule "${dstKey}". ` +
                         `This component doesn't have directive "${dstKey}".`,
                 );
-            } else if (supportedDestinationDirectives.indexOf(parsedComponent.directives[dstKey].type) < 0) {
+            } else if (supportedDestinationDirectives.indexOf(component.directives[dstKey].type) < 0) {
                 this.error(
-                    `Component "${parsedComponent.name}" has incorrect autofill rule "${dstKey}". ` +
+                    `Component "${component.name}" has incorrect autofill rule "${dstKey}". ` +
                         `Supported types of destination directive are "${supportedDestinationDirectives.join(
                             '", "',
                         )}" only.`,
@@ -55,31 +55,28 @@ export class AutofillValidator extends Validator {
             }
 
             // check if source directive exists
-            if (!parsedComponent.directives[rule.source]) {
+            if (!component.directives[rule.source]) {
                 this.error(
-                    `Component "${parsedComponent.name}" has incorrect autofill rule "${dstKey}". ` +
+                    `Component "${component.name}" has incorrect autofill rule "${dstKey}". ` +
                         `This component doesn't have directive "${rule.source}".`,
                 );
                 // Check if source directive is supported
-            } else if (supportedSourceDirectives.indexOf(parsedComponent.directives[rule.source].type) < 0) {
+            } else if (supportedSourceDirectives.indexOf(component.directives[rule.source].type) < 0) {
                 this.error(
-                    `Component "${parsedComponent.name}" has incorrect autofill rule "${dstKey}". ` +
+                    `Component "${component.name}" has incorrect autofill rule "${dstKey}". ` +
                         `Supported types of source directive are "${supportedSourceDirectives.join('", "')}" only.`,
                 );
                 // check if metadataField is set when source directive is image kind
-            } else if (
-                parsedComponent.directives[rule.source].type === DirectiveType.image &&
-                !('metadataField' in rule)
-            ) {
+            } else if (component.directives[rule.source].type === DirectiveType.image && !('metadataField' in rule)) {
                 this.error(
-                    `Component "${parsedComponent.name}" has incorrect autofill rule "${dstKey}". ` +
+                    `Component "${component.name}" has incorrect autofill rule "${dstKey}". ` +
                         `If source directive is image kind then "metadataField" must be set.`,
                 );
             }
             // check if dst !== src
             if (dstKey === rule.source) {
                 this.error(
-                    `Component "${parsedComponent.name}" has incorrect autofill rule "${dstKey}". ` +
+                    `Component "${component.name}" has incorrect autofill rule "${dstKey}". ` +
                         `There is no sense to fill directive content from itself.`,
                 );
             }

--- a/lib/validators/default-component-on-enter-override-validator.ts
+++ b/lib/validators/default-component-on-enter-override-validator.ts
@@ -6,13 +6,13 @@ import { Validator } from './validator';
 
 export class DefaultComponentOnEnterOverrideValidator extends Validator {
     async validate(): Promise<void> {
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
+        for (const component of Object.values(this.componentSet.components)) {
             if (
-                parsedComponent.defaultComponentOnEnter &&
-                !(parsedComponent.defaultComponentOnEnter in this.componentSet.components)
+                component.defaultComponentOnEnter &&
+                !(component.defaultComponentOnEnter in this.componentSet.components)
             ) {
                 this.error(
-                    `Property "defaultComponentOnEnter" of "${parsedComponent.name}" points to non existing component "${parsedComponent.defaultComponentOnEnter}"`,
+                    `Property "defaultComponentOnEnter" of "${component.name}" points to non existing component "${component.defaultComponentOnEnter}"`,
                 );
             }
         }

--- a/lib/validators/default-values-validator.ts
+++ b/lib/validators/default-values-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent, ComponentProperty } from '../models';
+import { Component, ComponentProperty } from '../models';
 import {
     ComponentPropertyControlCheckbox,
     ComponentPropertyControlRadio,
@@ -34,7 +34,7 @@ export class DefaultValuesValidator extends Validator {
     /**
      * Iterate through all properties of given component.
      */
-    private validateComponent(component: ParsedComponent): void {
+    private validateComponent(component: Component): void {
         component.properties.forEach((property) => this.validateProperty(property));
     }
 

--- a/lib/validators/directive-options-validator.ts
+++ b/lib/validators/directive-options-validator.ts
@@ -7,28 +7,28 @@ import { Component } from '../models';
 
 export class DirectiveOptionsValidator extends Validator {
     async validate(): Promise<void> {
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
-            this.validateComponent(parsedComponent);
+        for (const component of Object.values(this.componentSet.components)) {
+            this.validateComponent(component);
         }
     }
 
     /**
      * Validates whether directiveOptions entries have a matching directive
      */
-    validateComponent(parsedComponent: Component): void {
-        if (!parsedComponent.directiveOptions) {
+    validateComponent(component: Component): void {
+        if (!component.directiveOptions) {
             return;
         }
 
-        for (const key of Object.keys(parsedComponent.directiveOptions)) {
-            this.validateDirectiveOption(key, parsedComponent);
+        for (const key of Object.keys(component.directiveOptions)) {
+            this.validateDirectiveOption(key, component);
         }
     }
 
-    validateDirectiveOption(directiveKey: string, parsedComponent: Component): void {
-        if (!parsedComponent.directives[directiveKey]) {
+    validateDirectiveOption(directiveKey: string, component: Component): void {
+        if (!component.directives[directiveKey]) {
             this.error(
-                `Component "${parsedComponent.name}" has directive options for an unknown directive "${directiveKey}".`,
+                `Component "${component.name}" has directive options for an unknown directive "${directiveKey}".`,
             );
         }
     }

--- a/lib/validators/directive-options-validator.ts
+++ b/lib/validators/directive-options-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent } from '../models';
+import { Component } from '../models';
 
 export class DirectiveOptionsValidator extends Validator {
     async validate(): Promise<void> {
@@ -15,7 +15,7 @@ export class DirectiveOptionsValidator extends Validator {
     /**
      * Validates whether directiveOptions entries have a matching directive
      */
-    validateComponent(parsedComponent: ParsedComponent): void {
+    validateComponent(parsedComponent: Component): void {
         if (!parsedComponent.directiveOptions) {
             return;
         }
@@ -25,7 +25,7 @@ export class DirectiveOptionsValidator extends Validator {
         }
     }
 
-    validateDirectiveOption(directiveKey: string, parsedComponent: ParsedComponent): void {
+    validateDirectiveOption(directiveKey: string, parsedComponent: Component): void {
         if (!parsedComponent.directives[directiveKey]) {
             this.error(
                 `Component "${parsedComponent.name}" has directive options for an unknown directive "${directiveKey}".`,

--- a/lib/validators/directive-properties-validator.ts
+++ b/lib/validators/directive-properties-validator.ts
@@ -18,18 +18,18 @@ export class DirectivePropertiesValidator extends Validator {
             'i',
         );
 
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
-            parsedComponent.properties.forEach((parsedProperty) => {
+        for (const component of Object.values(this.componentSet.components)) {
+            component.properties.forEach((parsedProperty) => {
                 if (CONTROLS.indexOf(parsedProperty.control.type) >= 0 && !parsedProperty.directiveKey) {
                     this.error(
-                        `Property "${parsedProperty.name}" of component "${parsedComponent.name}" must reference ` +
+                        `Property "${parsedProperty.name}" of component "${component.name}" must reference ` +
                             `to a directive`,
                     );
                 }
                 // check all dataType=doc-* properties
                 if (regexp.test(parsedProperty.dataType) && !parsedProperty.directiveKey) {
                     this.error(
-                        `Property "${parsedProperty.name}" of component "${parsedComponent.name}" must reference ` +
+                        `Property "${parsedProperty.name}" of component "${component.name}" must reference ` +
                             `to a directive because its dataType is a directive type`,
                     );
                 }

--- a/lib/validators/disable-fullscreen-checkbox-validator.ts
+++ b/lib/validators/disable-fullscreen-checkbox-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent, ComponentProperty } from '../models';
+import { Component, ComponentProperty } from '../models';
 
 const CONTROL = 'disable-fullscreen-checkbox';
 const ALLOWED_DATA_TYPE = 'styles';
@@ -19,7 +19,7 @@ export class DisableFullscreenCheckboxValidator extends Validator {
      * @param errorReporter
      * @param component
      */
-    private validateComponent(component: ParsedComponent): void {
+    private validateComponent(component: Component): void {
         component.properties.forEach((property) => this.validateProperty(property));
     }
 

--- a/lib/validators/doc-container-groups-validator.ts
+++ b/lib/validators/doc-container-groups-validator.ts
@@ -7,7 +7,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent } from '../models';
+import { Component } from '../models';
 import { GroupsValidator } from './groups-validator';
 
 export class DocContainerGroupsValidator extends Validator {
@@ -26,7 +26,7 @@ export class DocContainerGroupsValidator extends Validator {
      * @param errorReporter
      * @param parsedComponent
      */
-    validateComponent(parsedComponent: ParsedComponent): void {
+    validateComponent(parsedComponent: Component): void {
         if (!parsedComponent.directiveOptions) {
             return;
         }

--- a/lib/validators/doc-container-groups-validator.ts
+++ b/lib/validators/doc-container-groups-validator.ts
@@ -13,8 +13,8 @@ import { GroupsValidator } from './groups-validator';
 export class DocContainerGroupsValidator extends Validator {
     async validate(): Promise<void> {
         // Find slides control properties and check for include and exclude
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
-            this.validateComponent(parsedComponent);
+        for (const component of Object.values(this.componentSet.components)) {
+            this.validateComponent(component);
         }
     }
 
@@ -24,27 +24,27 @@ export class DocContainerGroupsValidator extends Validator {
      * They should also pass the group validator.
      *
      * @param errorReporter
-     * @param parsedComponent
+     * @param component
      */
-    validateComponent(parsedComponent: Component): void {
-        if (!parsedComponent.directiveOptions) {
+    validateComponent(component: Component): void {
+        if (!component.directiveOptions) {
             return;
         }
 
         const groupsValidator = new GroupsValidator(this.error, this.componentSet);
 
-        for (const [key, directiveOptions] of Object.entries(parsedComponent.directiveOptions)) {
+        for (const [key, directiveOptions] of Object.entries(component.directiveOptions)) {
             // Rules only apply when it has a groups property defined
             if (!directiveOptions.groups) {
                 continue;
             }
-            if (!parsedComponent.directives[key]) {
-                this.error(`Component "${parsedComponent.name}" has a group for invalid directive "${key}"`);
+            if (!component.directives[key]) {
+                this.error(`Component "${component.name}" has a group for invalid directive "${key}"`);
                 continue;
             }
-            if (parsedComponent.directives[key].type !== 'container') {
+            if (component.directives[key].type !== 'container') {
                 this.error(
-                    `Component "${parsedComponent.name}" has a group for directive "${key}" with incompatible type "${parsedComponent.directives[key].type}". Only type "container" is allowed.`,
+                    `Component "${component.name}" has a group for directive "${key}" with incompatible type "${component.directives[key].type}". Only type "container" is allowed.`,
                 );
                 continue;
             }

--- a/lib/validators/doc-container-validator.ts
+++ b/lib/validators/doc-container-validator.ts
@@ -7,32 +7,30 @@ import { DirectiveType, Component } from '../models';
 
 export class DocContainerValidator extends Validator {
     async validate(): Promise<void> {
-        Object.values(this.componentSet.components).forEach((parsedComponent: Component) => {
-            const containerCount = this.countContainerDirectives(parsedComponent);
-            const slideshowCount = this.countSlideshowDirectives(parsedComponent);
+        Object.values(this.componentSet.components).forEach((component: Component) => {
+            const containerCount = this.countContainerDirectives(component);
+            const slideshowCount = this.countSlideshowDirectives(component);
 
             // check if there is not more than one doc-container
             // and it cannot be combined with slideshow directives
             if (containerCount > 1) {
-                this.error(`Component "${parsedComponent.name}" can only have one container directive`);
+                this.error(`Component "${component.name}" can only have one container directive`);
             } else if (containerCount === 1 && slideshowCount > 0) {
                 this.error(
-                    `Component "${parsedComponent.name}" contains both a container and slideshow directive,` +
+                    `Component "${component.name}" contains both a container and slideshow directive,` +
                         `but can only contain one of those directive types`,
                 );
             }
         });
     }
 
-    private countContainerDirectives(parsedComponent: Component): number {
-        return Object.values(parsedComponent.directives).filter(
-            (directive) => directive.type === DirectiveType.container,
-        ).length;
+    private countContainerDirectives(component: Component): number {
+        return Object.values(component.directives).filter((directive) => directive.type === DirectiveType.container)
+            .length;
     }
 
-    private countSlideshowDirectives(parsedComponent: Component): number {
-        return Object.values(parsedComponent.directives).filter(
-            (directive) => directive.type === DirectiveType.slideshow,
-        ).length;
+    private countSlideshowDirectives(component: Component): number {
+        return Object.values(component.directives).filter((directive) => directive.type === DirectiveType.slideshow)
+            .length;
     }
 }

--- a/lib/validators/doc-container-validator.ts
+++ b/lib/validators/doc-container-validator.ts
@@ -3,11 +3,11 @@
  */
 
 import { Validator } from './validator';
-import { DirectiveType, ParsedComponent } from '../models';
+import { DirectiveType, Component } from '../models';
 
 export class DocContainerValidator extends Validator {
     async validate(): Promise<void> {
-        Object.values(this.componentSet.components).forEach((parsedComponent: ParsedComponent) => {
+        Object.values(this.componentSet.components).forEach((parsedComponent: Component) => {
             const containerCount = this.countContainerDirectives(parsedComponent);
             const slideshowCount = this.countSlideshowDirectives(parsedComponent);
 
@@ -24,13 +24,13 @@ export class DocContainerValidator extends Validator {
         });
     }
 
-    private countContainerDirectives(parsedComponent: ParsedComponent): number {
+    private countContainerDirectives(parsedComponent: Component): number {
         return Object.values(parsedComponent.directives).filter(
             (directive) => directive.type === DirectiveType.container,
         ).length;
     }
 
-    private countSlideshowDirectives(parsedComponent: ParsedComponent): number {
+    private countSlideshowDirectives(parsedComponent: Component): number {
         return Object.values(parsedComponent.directives).filter(
             (directive) => directive.type === DirectiveType.slideshow,
         ).length;

--- a/lib/validators/doc-media-validator.ts
+++ b/lib/validators/doc-media-validator.ts
@@ -9,14 +9,14 @@
  */
 
 import { Validator } from './validator';
-import { ComponentProperty, DirectiveType, ParsedComponent } from '../models';
+import { ComponentProperty, DirectiveType, Component } from '../models';
 
 export class DocMediaValidator extends Validator {
     async validate(): Promise<void> {
-        Object.values(this.componentSet.components).forEach((c: ParsedComponent) => this.validateComponent(c));
+        Object.values(this.componentSet.components).forEach((c: Component) => this.validateComponent(c));
     }
 
-    private validateComponent(parsedComponent: ParsedComponent) {
+    private validateComponent(parsedComponent: Component) {
         const numMediaDirectives = this.countMediaDirectives(parsedComponent);
         if (numMediaDirectives === 0) {
             this.validateComponentWithoutMediaDirective(parsedComponent);
@@ -33,7 +33,7 @@ export class DocMediaValidator extends Validator {
         this.validateComponentWithMediaDirective(parsedComponent);
     }
 
-    private validateComponentWithoutMediaDirective(parsedComponent: ParsedComponent) {
+    private validateComponentWithoutMediaDirective(parsedComponent: Component) {
         if (this.countMediaPropertiesProperties(parsedComponent) > 0) {
             this.error(
                 `Component "${parsedComponent.name}" has a "media-properties" control type, but only components with a "doc-media" directive can have a property with this control type`,
@@ -41,7 +41,7 @@ export class DocMediaValidator extends Validator {
         }
     }
 
-    private validateComponentWithMediaDirective(parsedComponent: ParsedComponent) {
+    private validateComponentWithMediaDirective(parsedComponent: Component) {
         if (this.countMediaPropertiesProperties(parsedComponent) !== 1) {
             this.error(
                 `Component "${
@@ -59,7 +59,7 @@ export class DocMediaValidator extends Validator {
         }
     }
 
-    private validateMediaProperty(parsedComponent: ParsedComponent, mediaProperty: ComponentProperty) {
+    private validateMediaProperty(parsedComponent: Component, mediaProperty: ComponentProperty) {
         if (!mediaProperty.directiveKey) {
             this.error(
                 `Component "${parsedComponent.name}" must configure "directiveKey" for the property with control type "media-properties"`,
@@ -75,18 +75,18 @@ export class DocMediaValidator extends Validator {
         }
     }
 
-    private countMediaDirectives(parsedComponent: ParsedComponent): number {
+    private countMediaDirectives(parsedComponent: Component): number {
         return Object.values(parsedComponent.directives).filter((directive) => directive.type === DirectiveType.media)
             .length;
     }
 
     /** Count number of "media-properties" properties */
-    private countMediaPropertiesProperties(parsedComponent: ParsedComponent): number {
+    private countMediaPropertiesProperties(parsedComponent: Component): number {
         return this.mediaPropertiesProperties(parsedComponent).length;
     }
 
     /** Get "media-properties" properties definitions (collection of nested properties behaving as a single property) */
-    private mediaPropertiesProperties(parsedComponent: ParsedComponent) {
+    private mediaPropertiesProperties(parsedComponent: Component) {
         return Object.values(parsedComponent.properties).filter(
             (property) => property.control.type === 'media-properties',
         );

--- a/lib/validators/doc-media-validator.ts
+++ b/lib/validators/doc-media-validator.ts
@@ -16,79 +16,74 @@ export class DocMediaValidator extends Validator {
         Object.values(this.componentSet.components).forEach((c: Component) => this.validateComponent(c));
     }
 
-    private validateComponent(parsedComponent: Component) {
-        const numMediaDirectives = this.countMediaDirectives(parsedComponent);
+    private validateComponent(component: Component) {
+        const numMediaDirectives = this.countMediaDirectives(component);
         if (numMediaDirectives === 0) {
-            this.validateComponentWithoutMediaDirective(parsedComponent);
+            this.validateComponentWithoutMediaDirective(component);
             return;
         }
 
         if (numMediaDirectives > 1) {
-            this.error(
-                `Component "${parsedComponent.name}" can only have one "doc-media" directive in the HTML definition`,
-            );
+            this.error(`Component "${component.name}" can only have one "doc-media" directive in the HTML definition`);
             return;
         }
 
-        this.validateComponentWithMediaDirective(parsedComponent);
+        this.validateComponentWithMediaDirective(component);
     }
 
-    private validateComponentWithoutMediaDirective(parsedComponent: Component) {
-        if (this.countMediaPropertiesProperties(parsedComponent) > 0) {
+    private validateComponentWithoutMediaDirective(component: Component) {
+        if (this.countMediaPropertiesProperties(component) > 0) {
             this.error(
-                `Component "${parsedComponent.name}" has a "media-properties" control type, but only components with a "doc-media" directive can have a property with this control type`,
+                `Component "${component.name}" has a "media-properties" control type, but only components with a "doc-media" directive can have a property with this control type`,
             );
         }
     }
 
-    private validateComponentWithMediaDirective(parsedComponent: Component) {
-        if (this.countMediaPropertiesProperties(parsedComponent) !== 1) {
+    private validateComponentWithMediaDirective(component: Component) {
+        if (this.countMediaPropertiesProperties(component) !== 1) {
             this.error(
                 `Component "${
-                    parsedComponent.name
+                    component.name
                 }" with "doc-media" directive must have exactly one "media-properties" property (found ${this.countMediaPropertiesProperties(
-                    parsedComponent,
+                    component,
                 )})`,
             );
             return;
         }
 
         // Check whether the media-properties control type property is applied to the doc-media directive.
-        for (const mediaProperty of Object.values(this.mediaPropertiesProperties(parsedComponent))) {
-            this.validateMediaProperty(parsedComponent, mediaProperty);
+        for (const mediaProperty of Object.values(this.mediaPropertiesProperties(component))) {
+            this.validateMediaProperty(component, mediaProperty);
         }
     }
 
-    private validateMediaProperty(parsedComponent: Component, mediaProperty: ComponentProperty) {
+    private validateMediaProperty(component: Component, mediaProperty: ComponentProperty) {
         if (!mediaProperty.directiveKey) {
             this.error(
-                `Component "${parsedComponent.name}" must configure "directiveKey" for the property with control type "media-properties"`,
+                `Component "${component.name}" must configure "directiveKey" for the property with control type "media-properties"`,
             );
             return;
         }
 
-        const directive = parsedComponent.directives[mediaProperty.directiveKey];
+        const directive = component.directives[mediaProperty.directiveKey];
         if (!directive || directive.type !== DirectiveType.media) {
             this.error(
-                `Component "${parsedComponent.name}" has a control type "media-properties" applied to the wrong directive, which can only be used with "doc-media" directives`,
+                `Component "${component.name}" has a control type "media-properties" applied to the wrong directive, which can only be used with "doc-media" directives`,
             );
         }
     }
 
-    private countMediaDirectives(parsedComponent: Component): number {
-        return Object.values(parsedComponent.directives).filter((directive) => directive.type === DirectiveType.media)
-            .length;
+    private countMediaDirectives(component: Component): number {
+        return Object.values(component.directives).filter((directive) => directive.type === DirectiveType.media).length;
     }
 
     /** Count number of "media-properties" properties */
-    private countMediaPropertiesProperties(parsedComponent: Component): number {
-        return this.mediaPropertiesProperties(parsedComponent).length;
+    private countMediaPropertiesProperties(component: Component): number {
+        return this.mediaPropertiesProperties(component).length;
     }
 
     /** Get "media-properties" properties definitions (collection of nested properties behaving as a single property) */
-    private mediaPropertiesProperties(parsedComponent: Component) {
-        return Object.values(parsedComponent.properties).filter(
-            (property) => property.control.type === 'media-properties',
-        );
+    private mediaPropertiesProperties(component: Component) {
+        return Object.values(component.properties).filter((property) => property.control.type === 'media-properties');
     }
 }

--- a/lib/validators/doc-slideshow-validator.ts
+++ b/lib/validators/doc-slideshow-validator.ts
@@ -3,11 +3,11 @@
  */
 
 import { Validator } from './validator';
-import { DirectiveType, ParsedComponent } from '../models';
+import { DirectiveType, Component } from '../models';
 
 export class DocSlideshowValidator extends Validator {
     async validate(): Promise<void> {
-        Object.values(this.componentSet.components).forEach((parsedComponent: ParsedComponent) => {
+        Object.values(this.componentSet.components).forEach((parsedComponent: Component) => {
             const amountOfSlideshows = this.countSlideshowDirectives(parsedComponent);
             // check if it's the only one
             if (amountOfSlideshows > 1) {
@@ -19,7 +19,7 @@ export class DocSlideshowValidator extends Validator {
         });
     }
 
-    private countSlideshowDirectives(parsedComponent: ParsedComponent): number {
+    private countSlideshowDirectives(parsedComponent: Component): number {
         return Object.values(parsedComponent.directives).reduce((acc, directive) => {
             if (directive.type === DirectiveType.slideshow) {
                 acc++;

--- a/lib/validators/doc-slideshow-validator.ts
+++ b/lib/validators/doc-slideshow-validator.ts
@@ -7,20 +7,20 @@ import { DirectiveType, Component } from '../models';
 
 export class DocSlideshowValidator extends Validator {
     async validate(): Promise<void> {
-        Object.values(this.componentSet.components).forEach((parsedComponent: Component) => {
-            const amountOfSlideshows = this.countSlideshowDirectives(parsedComponent);
+        Object.values(this.componentSet.components).forEach((component: Component) => {
+            const amountOfSlideshows = this.countSlideshowDirectives(component);
             // check if it's the only one
             if (amountOfSlideshows > 1) {
                 this.error(
-                    `Component "${parsedComponent.name}" contains more then one slideshow directive, ` +
+                    `Component "${component.name}" contains more then one slideshow directive, ` +
                         `only one is allowed per component`,
                 );
             }
         });
     }
 
-    private countSlideshowDirectives(parsedComponent: Component): number {
-        return Object.values(parsedComponent.directives).reduce((acc, directive) => {
+    private countSlideshowDirectives(component: Component): number {
+        return Object.values(component.directives).reduce((acc, directive) => {
             if (directive.type === DirectiveType.slideshow) {
                 acc++;
             }

--- a/lib/validators/drop-capital-validator.ts
+++ b/lib/validators/drop-capital-validator.ts
@@ -5,13 +5,13 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent, ComponentProperty } from '../models';
+import { Component, ComponentProperty } from '../models';
 
 const CONTROL = 'drop-capital';
 const ALLOWED_DATA_TYPE = 'data';
 
 export class DropCapitalValidator extends Validator {
-    private countPerComponent(component: ParsedComponent): number {
+    private countPerComponent(component: Component): number {
         let amount = 0;
         component.properties.forEach((parsedProperty) => {
             if (parsedProperty.control.type === CONTROL) {
@@ -30,7 +30,7 @@ export class DropCapitalValidator extends Validator {
      *
      * @param component
      */
-    private validateComponent(component: ParsedComponent): void {
+    private validateComponent(component: Component): void {
         component.properties.forEach((property) => this.validateProperty(property));
 
         if (this.countPerComponent(component) > 1) {

--- a/lib/validators/fitting-validator.ts
+++ b/lib/validators/fitting-validator.ts
@@ -4,12 +4,12 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent } from '../models';
+import { Component } from '../models';
 
 const CONTROL = 'fitting';
 
 export class FittingValidator extends Validator {
-    private countPerComponent(component: ParsedComponent): number {
+    private countPerComponent(component: Component): number {
         let amount = 0;
         component.properties.forEach((parsedProperty) => {
             if (parsedProperty.control.type === CONTROL) {

--- a/lib/validators/fitting-validator.ts
+++ b/lib/validators/fitting-validator.ts
@@ -20,10 +20,10 @@ export class FittingValidator extends Validator {
     }
 
     async validate(): Promise<void> {
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
-            if (this.countPerComponent(parsedComponent) > 1) {
+        for (const component of Object.values(this.componentSet.components)) {
+            if (this.countPerComponent(component) > 1) {
                 this.error(
-                    `Component "${parsedComponent.name}" uses properties with "${CONTROL}" control type ` +
+                    `Component "${component.name}" uses properties with "${CONTROL}" control type ` +
                         `more that one time`,
                 );
             }

--- a/lib/validators/focuspoint-validator.ts
+++ b/lib/validators/focuspoint-validator.ts
@@ -6,17 +6,17 @@ import { Validator } from './validator';
 
 export class FocuspointValidator extends Validator {
     async validate(): Promise<void> {
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
-            parsedComponent.properties.forEach((parsedProperty) => {
+        for (const component of Object.values(this.componentSet.components)) {
+            component.properties.forEach((parsedProperty) => {
                 if (
                     parsedProperty.control.type === 'image-editor' &&
                     parsedProperty.control.focuspoint &&
                     parsedProperty.directiveKey && // skip, it's covered in other validator
-                    parsedComponent.directives[parsedProperty.directiveKey] && // skip, it's covered in other validator
-                    parsedComponent.directives[parsedProperty.directiveKey].tag === 'img'
+                    component.directives[parsedProperty.directiveKey] && // skip, it's covered in other validator
+                    component.directives[parsedProperty.directiveKey].tag === 'img'
                 ) {
                     this.error(
-                        `Property "${parsedProperty.name}" of component "${parsedComponent.name}" uses ` +
+                        `Property "${parsedProperty.name}" of component "${component.name}" uses ` +
                             `"focuspoint" feature on <img> html tag, which is not supported, "focuspoint" can be applied to other html tags, where` +
                             `image is a background`,
                     );

--- a/lib/validators/image-editor-validator.ts
+++ b/lib/validators/image-editor-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent, ComponentProperty } from '../models';
+import { Component, ComponentProperty } from '../models';
 
 const CONTROL = 'image-editor';
 const ALLOWED_DATA_TYPE = 'doc-image';
@@ -18,7 +18,7 @@ export class ImageEditorValidator extends Validator {
      *
      * @param component
      */
-    private validateComponent(component: ParsedComponent): void {
+    private validateComponent(component: Component): void {
         component.properties.forEach((property) => this.validateProperty(property));
     }
 

--- a/lib/validators/interactive-validator.ts
+++ b/lib/validators/interactive-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent, ComponentProperty } from '../models';
+import { Component, ComponentProperty } from '../models';
 
 const CONTROL = 'interactive';
 const ALLOWED_DATA_TYPE = 'doc-interactive';
@@ -18,7 +18,7 @@ export class InteractiveValidator extends Validator {
      *
      * @param component
      */
-    private validateComponent(component: ParsedComponent): void {
+    private validateComponent(component: Component): void {
         component.properties.forEach((property) => this.validateProperty(property));
     }
 

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -8,7 +8,7 @@
 
 import * as path from 'path';
 import { Validator } from './validator';
-import { ComponentProperty, ComponentSet, ParsedComponent } from '../models';
+import { ComponentProperty, ComponentSet, Component } from '../models';
 import type { ComponentPropertyControl } from '../models/component-property-controls';
 import * as semver from 'semver';
 
@@ -35,7 +35,7 @@ export class PropertiesValidator extends Validator {
         Object.values(this.componentSet.components).forEach((component) => this.validateComponent(component));
     }
 
-    private validateComponent(component: ParsedComponent): void {
+    private validateComponent(component: Component): void {
         const componentPropertyNames = new Set<string>();
 
         component.properties.forEach((property) => this.validateProperty(property, componentPropertyNames, component));
@@ -44,11 +44,7 @@ export class PropertiesValidator extends Validator {
         );
     }
 
-    private validateProperty(
-        property: ComponentProperty,
-        componentPropertyNames: Set<string>,
-        component: ParsedComponent,
-    ) {
+    private validateProperty(property: ComponentProperty, componentPropertyNames: Set<string>, component: Component) {
         this.validateReservedPropertyName(property);
         this.validatePropertyName(property, componentPropertyNames, component);
         this.validateRadioPropertyIcons(property);
@@ -58,7 +54,7 @@ export class PropertiesValidator extends Validator {
     private validatePropertyName(
         property: ComponentProperty,
         componentPropertyNames: Set<string>,
-        component: ParsedComponent,
+        component: Component,
     ) {
         if (!property.name) {
             this.validateNamelessProperty(property, component);
@@ -82,7 +78,7 @@ export class PropertiesValidator extends Validator {
         }
     }
 
-    private validateNamelessProperty(property: ComponentProperty, component: ParsedComponent) {
+    private validateNamelessProperty(property: ComponentProperty, component: Component) {
         if (property.control.type !== 'header') {
             this.error(
                 `Property in component "${component.name}" must have a name when using control type "${property.control.type}"`,
@@ -120,7 +116,7 @@ export class PropertiesValidator extends Validator {
     private validateChildProperties(
         property: ComponentProperty,
         componentPropertyNames: Set<string>,
-        component: ParsedComponent,
+        component: Component,
     ) {
         if (!property.childProperties) return;
 

--- a/lib/validators/restrict-children-validator.ts
+++ b/lib/validators/restrict-children-validator.ts
@@ -3,20 +3,20 @@
  */
 
 import { Validator } from './validator';
-import { DirectiveType, ParsedComponent } from '../models';
+import { DirectiveType, Component } from '../models';
 
 const PROPERTY = 'restrictChildren';
 const ADDITIONAL_PROPERTY = 'withContent';
 
 export class RestrictChildrenValidator extends Validator {
-    private hasSlideshowDirective(parsedComponent: ParsedComponent): boolean {
+    private hasSlideshowDirective(parsedComponent: Component): boolean {
         return Object.values(parsedComponent.directives).some(
             (directive) => directive.type === DirectiveType.slideshow,
         );
     }
 
     async validate(): Promise<void> {
-        Object.values(this.componentSet.components).forEach((parsedComponent: ParsedComponent) => {
+        Object.values(this.componentSet.components).forEach((parsedComponent: Component) => {
             const isPresent = PROPERTY in parsedComponent && parsedComponent[PROPERTY];
             const hasSlideshow = this.hasSlideshowDirective(parsedComponent);
             if (!isPresent) {

--- a/lib/validators/restrict-children-validator.ts
+++ b/lib/validators/restrict-children-validator.ts
@@ -9,42 +9,40 @@ const PROPERTY = 'restrictChildren';
 const ADDITIONAL_PROPERTY = 'withContent';
 
 export class RestrictChildrenValidator extends Validator {
-    private hasSlideshowDirective(parsedComponent: Component): boolean {
-        return Object.values(parsedComponent.directives).some(
-            (directive) => directive.type === DirectiveType.slideshow,
-        );
+    private hasSlideshowDirective(component: Component): boolean {
+        return Object.values(component.directives).some((directive) => directive.type === DirectiveType.slideshow);
     }
 
     async validate(): Promise<void> {
-        Object.values(this.componentSet.components).forEach((parsedComponent: Component) => {
-            const isPresent = PROPERTY in parsedComponent && parsedComponent[PROPERTY];
-            const hasSlideshow = this.hasSlideshowDirective(parsedComponent);
+        Object.values(this.componentSet.components).forEach((component: Component) => {
+            const isPresent = PROPERTY in component && component[PROPERTY];
+            const hasSlideshow = this.hasSlideshowDirective(component);
             if (!isPresent) {
                 if (hasSlideshow) {
                     this.error(
-                        `Component property "${PROPERTY}" must be defined in component "${parsedComponent.name}" because the ` +
+                        `Component property "${PROPERTY}" must be defined in component "${component.name}" because the ` +
                             `component contains a slideshow directive`,
                     );
                 }
                 return;
             }
             const propertyValue =
-                parsedComponent[PROPERTY] ||
+                component[PROPERTY] ||
                 // satisfy the compiler -> if PROPERTY exists then it is a non empty object otherwise it can't pass the schema
                 {};
             const propertyKeys = Object.keys(propertyValue);
             // slideshow component can have only one entry
             if (hasSlideshow && propertyKeys.length > 1) {
                 this.error(
-                    `Component property "${PROPERTY}" of component "${parsedComponent.name}" must contain only one entry` +
+                    `Component property "${PROPERTY}" of component "${component.name}" must contain only one entry` +
                         ` because the component contains a slideshow directive`,
                 );
             }
             // check if all keys point to correct component
             propertyKeys.forEach((componentName: string) => {
-                if (componentName === parsedComponent.name) {
+                if (componentName === component.name) {
                     this.error(
-                        `Component property "${PROPERTY}.${componentName}" of component "${parsedComponent.name}" points to itself`,
+                        `Component property "${PROPERTY}.${componentName}" of component "${component.name}" points to itself`,
                     );
                     return;
                 }
@@ -56,14 +54,14 @@ export class RestrictChildrenValidator extends Validator {
                         if (!(additionalPropertyValue in pointedParsedComponent.directives)) {
                             this.error(
                                 `Additional property "${ADDITIONAL_PROPERTY}" of property "${PROPERTY}.${componentName}" of component ` +
-                                    `"${parsedComponent.name}" points to non existing directive key "${additionalPropertyValue}" of component ` +
+                                    `"${component.name}" points to non existing directive key "${additionalPropertyValue}" of component ` +
                                     `"${pointedParsedComponent.name}"`,
                             );
                         }
                     }
                 } else {
                     this.error(
-                        `Component property "${PROPERTY}.${componentName}" of component "${parsedComponent.name}" points to ` +
+                        `Component property "${PROPERTY}.${componentName}" of component "${component.name}" points to ` +
                             `non existing component`,
                     );
                 }

--- a/lib/validators/slides-validator.ts
+++ b/lib/validators/slides-validator.ts
@@ -8,9 +8,9 @@ import { Component, ComponentProperty } from '../models';
 export class SlidesValidator extends Validator {
     async validate(): Promise<void> {
         // Find slides control properties and check for include and exclude
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
-            parsedComponent.properties.forEach((property) => {
-                this.validateComponent(parsedComponent, property);
+        for (const component of Object.values(this.componentSet.components)) {
+            component.properties.forEach((property) => {
+                this.validateComponent(component, property);
             });
         }
     }
@@ -19,22 +19,18 @@ export class SlidesValidator extends Validator {
      * Validates when slides property is found for component.
      * Checks if restrictChildren is set and validates the include and exclude properties
      * are valid for the slide component of doc-slideshow.
-     *
-     * @param errorReporter
-     * @param parsedComponent
-     * @param property
      */
-    validateComponent(parsedComponent: Component, property: ComponentProperty): void {
+    validateComponent(component: Component, property: ComponentProperty): void {
         if (property.control.type !== 'slides') {
             return;
         }
 
-        if (!parsedComponent.restrictChildren) {
-            this.error(`Component "${parsedComponent.name}" must have restrictChildren set to use the slides property`);
+        if (!component.restrictChildren) {
+            this.error(`Component "${component.name}" must have restrictChildren set to use the slides property`);
             return;
         }
 
-        const slideComponentName = Object.keys(parsedComponent.restrictChildren)[0];
+        const slideComponentName = Object.keys(component.restrictChildren)[0];
         const slideComponent = this.componentSet.components[slideComponentName];
 
         if (property.control.include) {
@@ -47,18 +43,13 @@ export class SlidesValidator extends Validator {
 
     /**
      * Validate a list of property names are valid.
-     *
-     * @param errorReporter
-     * @param parsedComponent
-     * @param property
-     * @param properties
      */
-    private validateHasProperties(parsedComponent: Component, property: ComponentProperty, properties: string[]): void {
+    private validateHasProperties(component: Component, property: ComponentProperty, properties: string[]): void {
         properties.forEach((propertyName) => {
-            if (!this.hasProperty(parsedComponent, propertyName)) {
+            if (!this.hasProperty(component, propertyName)) {
                 this.error(
                     `Property "${property.name}" is referring to an invalid property "${propertyName}"` +
-                        `not part of "${parsedComponent.name}"`,
+                        `not part of "${component.name}"`,
                 );
             }
         });
@@ -66,13 +57,10 @@ export class SlidesValidator extends Validator {
 
     /**
      * Validate the component has the property.
-     *
-     * @param parsedComponent
-     * @param propertyName
      */
-    private hasProperty(parsedComponent: Component, propertyName: string) {
-        for (let i = 0; i < parsedComponent.properties.length; i++) {
-            if (parsedComponent.properties[i].name === propertyName) {
+    private hasProperty(component: Component, propertyName: string) {
+        for (let i = 0; i < component.properties.length; i++) {
+            if (component.properties[i].name === propertyName) {
                 return true;
             }
         }

--- a/lib/validators/slides-validator.ts
+++ b/lib/validators/slides-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent, ComponentProperty } from '../models';
+import { Component, ComponentProperty } from '../models';
 
 export class SlidesValidator extends Validator {
     async validate(): Promise<void> {
@@ -24,7 +24,7 @@ export class SlidesValidator extends Validator {
      * @param parsedComponent
      * @param property
      */
-    validateComponent(parsedComponent: ParsedComponent, property: ComponentProperty): void {
+    validateComponent(parsedComponent: Component, property: ComponentProperty): void {
         if (property.control.type !== 'slides') {
             return;
         }
@@ -53,11 +53,7 @@ export class SlidesValidator extends Validator {
      * @param property
      * @param properties
      */
-    private validateHasProperties(
-        parsedComponent: ParsedComponent,
-        property: ComponentProperty,
-        properties: string[],
-    ): void {
+    private validateHasProperties(parsedComponent: Component, property: ComponentProperty, properties: string[]): void {
         properties.forEach((propertyName) => {
             if (!this.hasProperty(parsedComponent, propertyName)) {
                 this.error(
@@ -74,7 +70,7 @@ export class SlidesValidator extends Validator {
      * @param parsedComponent
      * @param propertyName
      */
-    private hasProperty(parsedComponent: ParsedComponent, propertyName: string) {
+    private hasProperty(parsedComponent: Component, propertyName: string) {
         for (let i = 0; i < parsedComponent.properties.length; i++) {
             if (parsedComponent.properties[i].name === propertyName) {
                 return true;

--- a/lib/validators/strip-styling-on-paste-validator.ts
+++ b/lib/validators/strip-styling-on-paste-validator.ts
@@ -7,45 +7,45 @@ import { Component } from '../models';
 
 export class StripStylingOnPasteValidator extends Validator {
     async validate(): Promise<void> {
-        for (const parsedComponent of Object.values(this.componentSet.components)) {
-            this.validateComponent(parsedComponent);
+        for (const component of Object.values(this.componentSet.components)) {
+            this.validateComponent(component);
         }
     }
 
     /**
      * Validates whether stripStylingOnPaste is set for an editable directive.
      */
-    validateComponent(parsedComponent: Component): void {
-        if (!parsedComponent.directiveOptions) {
+    validateComponent(component: Component): void {
+        if (!component.directiveOptions) {
             return;
         }
 
-        for (const [key, directiveOptions] of Object.entries(parsedComponent.directiveOptions)) {
+        for (const [key, directiveOptions] of Object.entries(component.directiveOptions)) {
             // Only for directives with stripStylingOnPaste option
             if (directiveOptions.stripStylingOnPaste === undefined) continue;
 
-            if (!this.validateDirectiveExists(key, parsedComponent)) continue;
+            if (!this.validateDirectiveExists(key, component)) continue;
 
-            this.validateDirectiveType(key, parsedComponent);
+            this.validateDirectiveType(key, component);
         }
     }
 
-    validateDirectiveExists(directiveKey: string, parsedComponent: Component): boolean {
-        const directive = parsedComponent.directives[directiveKey];
+    validateDirectiveExists(directiveKey: string, component: Component): boolean {
+        const directive = component.directives[directiveKey];
         if (directive) return true;
 
         this.error(
-            `Component "${parsedComponent.name}" has stripStylingOnPaste set for an unknown directive "${directiveKey}".`,
+            `Component "${component.name}" has stripStylingOnPaste set for an unknown directive "${directiveKey}".`,
         );
         return false;
     }
 
-    validateDirectiveType(directiveKey: string, parsedComponent: Component): void {
-        const directive = parsedComponent.directives[directiveKey];
+    validateDirectiveType(directiveKey: string, component: Component): void {
+        const directive = component.directives[directiveKey];
         if (directive.type === 'editable') return;
 
         this.error(
-            `Component "${parsedComponent.name}" has stripStylingOnPaste set for a directive with key "${directiveKey}" but that directive is not of type "editable". Instead it is of type "${directive.type}".`,
+            `Component "${component.name}" has stripStylingOnPaste set for a directive with key "${directiveKey}" but that directive is not of type "editable". Instead it is of type "${directive.type}".`,
         );
     }
 }

--- a/lib/validators/strip-styling-on-paste-validator.ts
+++ b/lib/validators/strip-styling-on-paste-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent } from '../models';
+import { Component } from '../models';
 
 export class StripStylingOnPasteValidator extends Validator {
     async validate(): Promise<void> {
@@ -15,7 +15,7 @@ export class StripStylingOnPasteValidator extends Validator {
     /**
      * Validates whether stripStylingOnPaste is set for an editable directive.
      */
-    validateComponent(parsedComponent: ParsedComponent): void {
+    validateComponent(parsedComponent: Component): void {
         if (!parsedComponent.directiveOptions) {
             return;
         }
@@ -30,7 +30,7 @@ export class StripStylingOnPasteValidator extends Validator {
         }
     }
 
-    validateDirectiveExists(directiveKey: string, parsedComponent: ParsedComponent): boolean {
+    validateDirectiveExists(directiveKey: string, parsedComponent: Component): boolean {
         const directive = parsedComponent.directives[directiveKey];
         if (directive) return true;
 
@@ -40,7 +40,7 @@ export class StripStylingOnPasteValidator extends Validator {
         return false;
     }
 
-    validateDirectiveType(directiveKey: string, parsedComponent: ParsedComponent): void {
+    validateDirectiveType(directiveKey: string, parsedComponent: Component): void {
         const directive = parsedComponent.directives[directiveKey];
         if (directive.type === 'editable') return;
 

--- a/lib/validators/unit-type-validator.ts
+++ b/lib/validators/unit-type-validator.ts
@@ -3,7 +3,7 @@
  */
 
 import { Validator } from './validator';
-import { ParsedComponent, ComponentProperty } from '../models';
+import { Component, ComponentProperty } from '../models';
 
 const TYPES = ['em', 'px'];
 const TYPES_REGEXP = new RegExp(`^(${TYPES.join('|')})$`, 'i');
@@ -18,7 +18,7 @@ export class UnitTypeValidator extends Validator {
      *
      * @param component
      */
-    private validateComponent(component: ParsedComponent): void {
+    private validateComponent(component: Component): void {
         component.properties.forEach((property) => this.validateProperty(property));
     }
 


### PR DESCRIPTION
- Rename `Component` to `ComponentDefinition` 
- Rename `ParsedComponent` to `Component` (which is really the main type we would use).

I checked usage of `ParsedComponent` in the Digital Editor and not too many direct usages. So updating should be trivial.

As per ticket I also looked if we could change `Label` to `string` for the final type of the component set, as in the client it is always already translated. However this seems to result in a mess of types (not trivial to keep clean).