### PR TITLE
Remove lodash usage

### DIFF
--- a/lib/models/component-set.ts
+++ b/lib/models/component-set.ts
@@ -31,7 +31,7 @@ export interface ComponentSet {
     defaultComponentContent: {
         [componentName: string]: {
             [dataType in ComponentProperty['dataType']]?: {
-                [propertyName: string]: string;
+                [propertyName: string]: ComponentProperty['defaultValue'];
             };
         };
     };

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -38,11 +38,10 @@ export async function parseDefinition(componentsDefinition: ComponentsDefinition
         customStyles: componentsDefinition.customStyles || [],
     };
     // copy source because properties and child properties will be expanded
-    const definition: ComponentsDefinition = JSON.parse(JSON.stringify(componentsDefinition));
-    for (const compDef of definition.components) {
+    for (const compDef of componentsDefinition.components) {
         componentSet.components[compDef.name] = parseComponent(
             compDef,
-            definition.componentProperties,
+            componentsDefinition.componentProperties,
             ComponentRendition.HTML,
         );
     }
@@ -164,7 +163,7 @@ function findComponentPropertyTemplate(propertyName: string, componentProperties
     if (!propertyTemplate) {
         throw new Error(`Property "${propertyName}" is not found in definition componentProperties`);
     }
-    return propertyTemplate;
+    return Object.assign({}, propertyTemplate);
 }
 
 function isPropertyObject(property: unknown): property is ComponentProperty {

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -126,6 +126,7 @@ function parseProperty(
     componentProperty: ComponentProperty | string,
     componentProperties: ComponentProperty[],
 ): ComponentProperty {
+    // Creates a shallow clone of the property object, so properties can be re-assigned.
     return isPropertyObject(componentProperty)
         ? parseComponentPropertyObject(componentProperty, componentProperties)
         : findComponentPropertyTemplate(componentProperty, componentProperties);

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -94,21 +94,11 @@ function getDirectiveType(directiveName: string): DirectiveType {
 
 /**
  * Checks if component has needed rendition
- *
- * @param component
- * @param rendition
  */
 function hasRendition(component: ComponentDefinition, rendition: ComponentRendition): boolean {
     return Boolean(component.renditions && rendition in component.renditions);
 }
 
-/**
- * Parses a component
- *
- * @param component
- * @param componentProperties
- * @param rendition
- */
 function parseComponent(
     component: ComponentDefinition,
     componentProperties: ComponentProperty[],
@@ -132,12 +122,6 @@ function parseComponent(
     };
 }
 
-/**
- * Parses a property
- *
- * @param componentProperty
- * @param componentProperties
- */
 function parseProperty(
     componentProperty: ComponentProperty | string,
     componentProperties: ComponentProperty[],
@@ -215,8 +199,6 @@ function validateDirective(
  * content with the properties classes, as both deal with the article format.
  * Alternatively the default values could be set after component creation, but this would
  * generate more data operations and trigger more view updates (needs to be tested through).
- *
- * @param componentSet
  */
 function buildComponentSetDefaultContent(componentSet: ComponentSet): void {
     for (const component of Object.values(componentSet.components)) {
@@ -226,9 +208,6 @@ function buildComponentSetDefaultContent(componentSet: ComponentSet): void {
 
 /**
  * Build default component model for given component and add to defaultComponentContent input.
- *
- * @param defaultComponentContent
- * @param component
  */
 function buildComponentDefaultContent(
     defaultComponentContent: ComponentSet['defaultComponentContent'],
@@ -264,10 +243,6 @@ function buildConditionalChildPropertiesDefaultContent(
 
 /**
  * Build default component model property data and add to defaultComponentContent.
- *
- * @param defaultComponentContent
- * @param componentName
- * @param property
  */
 function buildComponentPropertyDefaultContent(
     defaultComponentContent: ComponentSet['defaultComponentContent'],

--- a/lib/renditions/utils.ts
+++ b/lib/renditions/utils.ts
@@ -1,19 +1,27 @@
 import * as path from 'path';
 import { ComponentDefinition, ComponentRendition, ComponentsDefinition, GetFileContentType } from '../models';
-import cloneDeep = require('lodash.clonedeep');
-import { deepFreeze } from '../util/freeze';
 
 export async function loadHtmlRenditions(
     componentsDefinition: ComponentsDefinition,
     getFileContent: GetFileContentType,
 ): Promise<ComponentsDefinition> {
-    const enrichedDefinition = cloneDeep(componentsDefinition);
-    for (const compDef of enrichedDefinition.components) {
+    return {
+        ...componentsDefinition,
+        components: await loadRenditionsForComponents(componentsDefinition.components, getFileContent),
+    };
+}
+
+async function loadRenditionsForComponents(components: ComponentDefinition[], getFileContent: GetFileContentType) {
+    const enrichedComponents: ComponentDefinition[] = [];
+    for (const compDef of components) {
         if (!hasRendition(compDef, ComponentRendition.HTML)) {
-            await loadRendition(compDef, ComponentRendition.HTML, getFileContent);
+            enrichedComponents.push({
+                ...compDef,
+                renditions: await loadRendition(compDef.name, ComponentRendition.HTML, getFileContent),
+            });
         }
     }
-    return deepFreeze(enrichedDefinition);
+    return enrichedComponents;
 }
 
 function hasRendition(component: ComponentDefinition, rendition: ComponentRendition): boolean {
@@ -21,18 +29,13 @@ function hasRendition(component: ComponentDefinition, rendition: ComponentRendit
 }
 
 async function loadRendition(
-    component: ComponentDefinition,
+    componentName: string,
     rendition: ComponentRendition,
     getFileContent: GetFileContentType,
-): Promise<ComponentDefinition> {
-    if (!component.renditions) {
-        component.renditions = {};
-    }
-    component.renditions[rendition] = (await getFileContent(
-        path.normalize(`templates/${rendition}/${component.name}.html`),
-        {
-            encoding: 'utf8',
-        },
-    )) as string;
-    return component;
+): Promise<ComponentDefinition['renditions']> {
+    const renditions: ComponentDefinition['renditions'] = {};
+    renditions[rendition] = (await getFileContent(path.normalize(`templates/${rendition}/${componentName}.html`), {
+        encoding: 'utf8',
+    })) as string;
+    return renditions;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -865,34 +865,10 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.168",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
-      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
-      "dev": true
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.merge": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/node": {
-      "version": "12.20.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.27.tgz",
-      "integrity": "sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg==",
+      "version": "12.20.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.28.tgz",
+      "integrity": "sha512-cBw8gzxUPYX+/5lugXIPksioBSbE42k0fZ39p+4yRzfYjN6++eq9kAPdlY9qm+MXyfbk9EmvCYAYRn380sF46w==",
       "dev": true
     },
     "@types/parse5": {
@@ -3586,16 +3562,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
   "devDependencies": {
     "@types/jest": "^27.0.0",
     "@types/json-schema": "~7.0.7",
-    "@types/lodash.clonedeep": "^4.5.6",
-    "@types/lodash.merge": "^4.6.6",
-    "@types/node": "^12.12.6",
+    "@types/node": "^12.20.28",
     "@types/parse5": "^6.0.0",
     "@types/pngjs": "^6.0.0",
     "@types/recursive-readdir": "^2.2.0",
@@ -59,8 +57,6 @@
     "chalk": "~4.1.1",
     "htmlparser2": "^6.1.0",
     "json-source-map": "^0.6.1",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.merge": "^4.6.2",
     "parse5": "^6.0.1",
     "pngjs": "^3.3.0",
     "semver": "^7.3.0"

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -1,41 +1,54 @@
 import { PropertiesValidator } from '../../lib/validators';
 import type { ComponentProperty } from '../../lib/models';
-import cloneDeep = require('lodash.clonedeep');
 
 describe('PropertiesValidator', () => {
-    const textProperty: ComponentProperty = {
-        name: 'textProperty',
-        control: {
-            type: 'text',
-        },
-    } as any;
-    const radioProperty: ComponentProperty = {
-        name: 'radioProperty',
-        control: {
-            type: 'radio',
-            options: [{ icon: 'path1' }, { icon: 'path2' }, { icon: 'path5' }],
-        },
-    } as any;
-    const mediaProperty: ComponentProperty = {
-        name: 'mediaProperty',
-        control: {
-            type: 'media-properties',
-        },
-        dataType: 'doc-media',
-    } as any;
-    const headerProperty: ComponentProperty = {
-        control: {
-            type: 'header',
-        },
-        label: 'header-label',
-    } as any;
-    const checkboxProperty: ComponentProperty = {
-        name: 'checkboxProperty',
-        control: {
-            type: 'checkbox',
-            value: true,
-        },
-    } as any;
+    function createTextProperty(): ComponentProperty {
+        return {
+            name: 'textProperty',
+            control: {
+                type: 'text',
+            },
+        } as any;
+    }
+
+    function createRadioProperty(): ComponentProperty {
+        return {
+            name: 'radioProperty',
+            control: {
+                type: 'radio',
+                options: [{ icon: 'path1' }, { icon: 'path2' }, { icon: 'path5' }],
+            },
+        } as any;
+    }
+
+    function createMediaProperty(): ComponentProperty {
+        return {
+            name: 'mediaProperty',
+            control: {
+                type: 'media-properties',
+            },
+            dataType: 'doc-media',
+        } as any;
+    }
+
+    function createHeaderProperty(): ComponentProperty {
+        return {
+            control: {
+                type: 'header',
+            },
+            label: 'header-label',
+        } as any;
+    }
+
+    function createCheckboxProperty(): ComponentProperty {
+        return {
+            name: 'checkboxProperty',
+            control: {
+                type: 'checkbox',
+                value: true,
+            },
+        } as any;
+    }
 
     function createConditionalProperty(children: any[]) {
         return {
@@ -59,12 +72,17 @@ describe('PropertiesValidator', () => {
             components: {
                 c1: {
                     name: 'c1',
-                    properties: params?.properties ?? [textProperty, radioProperty, mediaProperty, headerProperty],
+                    properties: params?.properties ?? [
+                        createTextProperty(),
+                        createRadioProperty(),
+                        createMediaProperty(),
+                        createHeaderProperty(),
+                    ],
                 },
                 // Add another component with same property to test uniqueness validation passes correctly
                 c2: {
                     name: 'c2',
-                    properties: [textProperty],
+                    properties: [createTextProperty()],
                 },
             },
         };
@@ -87,7 +105,7 @@ describe('PropertiesValidator', () => {
 
         it('should not pass if the names are not unique', () => {
             const { validator, errorSpy } = createPropertiesValidator({
-                properties: [{ ...cloneDeep(textProperty), name: 'radioProperty' }, radioProperty],
+                properties: [{ ...createTextProperty(), name: 'radioProperty' }, createRadioProperty()],
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
@@ -97,14 +115,14 @@ describe('PropertiesValidator', () => {
 
         it('should not pass if reserved word is used as a name', () => {
             const { validator, errorSpy } = createPropertiesValidator({
-                properties: [{ ...cloneDeep(textProperty), name: 'parallax' }],
+                properties: [{ ...createTextProperty(), name: 'parallax' }],
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(`Component property name "parallax" is a reserved word`);
         });
 
         it('should not pass if there is no icon file', () => {
-            const otherRadioProperty = cloneDeep(radioProperty) as any;
+            const otherRadioProperty = createRadioProperty() as any;
             otherRadioProperty.control.options[0].icon = 'pathU';
             const { validator, errorSpy } = createPropertiesValidator({
                 properties: [otherRadioProperty],
@@ -116,7 +134,7 @@ describe('PropertiesValidator', () => {
         it('should pass if parallax word is used as a name in version 1.4.0 or higher', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.4.0',
-                properties: [{ ...cloneDeep(textProperty), name: 'parallax' }],
+                properties: [{ ...createTextProperty(), name: 'parallax' }],
             });
             validator.validate();
             expect(errorSpy).not.toHaveBeenCalled();
@@ -125,7 +143,7 @@ describe('PropertiesValidator', () => {
         it('should pass if parallax word is used as a name in version 1.5.0 or higher', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.5.0',
-                properties: [{ ...cloneDeep(textProperty), name: 'parallax' }],
+                properties: [{ ...createTextProperty(), name: 'parallax' }],
             });
             validator.validate();
             expect(errorSpy).not.toHaveBeenCalled();
@@ -135,7 +153,7 @@ describe('PropertiesValidator', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.5.0',
                 properties: [
-                    textProperty,
+                    createTextProperty(),
                     { label: 'Header', control: { type: 'header' } },
                     { label: 'Another Header', control: { type: 'header' } },
                 ],
@@ -148,8 +166,8 @@ describe('PropertiesValidator', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.5.0',
                 properties: [
-                    { ...cloneDeep(textProperty), name: undefined },
-                    { ...cloneDeep(mediaProperty), name: undefined },
+                    { ...createTextProperty(), name: undefined },
+                    { ...createMediaProperty(), name: undefined },
                 ],
             });
             validator.validate();
@@ -163,7 +181,7 @@ describe('PropertiesValidator', () => {
 
         it('should not pass if a header has a dataType', () => {
             const { validator, errorSpy } = createPropertiesValidator({
-                properties: [{ ...cloneDeep(headerProperty), dataType: 'data' }],
+                properties: [{ ...createHeaderProperty(), dataType: 'data' }],
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
@@ -174,18 +192,18 @@ describe('PropertiesValidator', () => {
         it('should pass on valid conditional property definition (uses same property definition in other component)', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',
-                properties: [createConditionalProperty([textProperty])],
+                properties: [createConditionalProperty([createTextProperty()])],
             });
             validator.validate();
             expect(errorSpy).not.toHaveBeenCalled();
         });
 
         it('should pass when using the same conditional property definition in other conditions', () => {
-            const conditionalProperty = createConditionalProperty([textProperty]);
+            const conditionalProperty = createConditionalProperty([createTextProperty()]);
             conditionalProperty.childProperties.push({
                 matchType: 'exact-value',
                 matchExpression: 'some arbitrary value',
-                properties: [textProperty],
+                properties: [createTextProperty()],
             });
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',
@@ -198,7 +216,7 @@ describe('PropertiesValidator', () => {
         it('should not pass when using property with the same name in the conditional property definition as the parent', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',
-                properties: [textProperty, createConditionalProperty([textProperty])],
+                properties: [createTextProperty(), createConditionalProperty([createTextProperty()])],
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
@@ -210,7 +228,10 @@ describe('PropertiesValidator', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',
                 properties: [
-                    createConditionalProperty([{ ...cloneDeep(textProperty), name: 'radioProperty' }, radioProperty]),
+                    createConditionalProperty([
+                        { ...createTextProperty(), name: 'radioProperty' },
+                        createRadioProperty(),
+                    ]),
                 ],
             });
             validator.validate();
@@ -220,7 +241,7 @@ describe('PropertiesValidator', () => {
         });
 
         it('should not pass if a conditional child property has no icon file', () => {
-            const otherRadioProperty = cloneDeep(radioProperty) as any;
+            const otherRadioProperty = createRadioProperty() as any;
             otherRadioProperty.control.options[0].icon = 'pathU';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',
@@ -235,7 +256,7 @@ describe('PropertiesValidator', () => {
                 version: '1.7.0',
                 properties: [
                     createConditionalProperty([
-                        textProperty,
+                        createTextProperty(),
                         { label: 'Header', control: { type: 'header' } },
                         { label: 'Another Header', control: { type: 'header' } },
                     ]),
@@ -250,8 +271,8 @@ describe('PropertiesValidator', () => {
                 version: '1.7.0',
                 properties: [
                     createConditionalProperty([
-                        { ...cloneDeep(textProperty), name: undefined },
-                        { ...cloneDeep(mediaProperty), name: undefined },
+                        { ...createTextProperty(), name: undefined },
+                        { ...createMediaProperty(), name: undefined },
                     ]),
                 ],
             });
@@ -267,7 +288,7 @@ describe('PropertiesValidator', () => {
         it('should not pass if conditional child header has a dataType', () => {
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',
-                properties: [createConditionalProperty([{ ...cloneDeep(headerProperty), dataType: 'data' }])],
+                properties: [createConditionalProperty([{ ...createHeaderProperty(), dataType: 'data' }])],
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
@@ -280,7 +301,7 @@ describe('PropertiesValidator', () => {
                 version: '1.7.0',
                 properties: [
                     {
-                        ...createConditionalProperty([textProperty]),
+                        ...createConditionalProperty([createTextProperty()]),
                         control: {
                             type: 'fitting',
                         },
@@ -294,7 +315,7 @@ describe('PropertiesValidator', () => {
         });
 
         it('should pass if a checkbox with dataType "data" is used with a boolean value', () => {
-            const prop = cloneDeep(checkboxProperty);
+            const prop = createCheckboxProperty();
             prop.dataType = 'data';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',
@@ -305,7 +326,7 @@ describe('PropertiesValidator', () => {
         });
 
         it('should not pass if a checkbox with dataType other than "data" is used with a boolean value', () => {
-            const prop = cloneDeep(checkboxProperty);
+            const prop = createCheckboxProperty();
             prop.dataType = 'styles';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.7.0',


### PR DESCRIPTION
This PR removes the usage of lodash from the library:
- The used packages were last updated over 3 years ago.
- The main lodash package tends to cause security vulnerability warnings (annoying).

Instead rewrite the code to work without merge and cloneDeep. A few shallow clones are enough.

For `validate` entry point this should be  safe refactor, as it performs a deep freeze of the components definition object. This entry point also calls the parser utility. So the tests would quickly complain about not being able to assign properties.

In addition not doing a full clone everywhere is likely more performant as well (can be useful for our tests that need to parse the component definition).