### PR TITLE
ECS-447: allow boolean as defaultValue for checkbox

### DIFF
--- a/lib/components-schema-v1_8_x.ts
+++ b/lib/components-schema-v1_8_x.ts
@@ -9,7 +9,7 @@
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 const defaultValue: JSONSchema7Definition = {
-    type: ['integer', 'string', 'number', 'object'],
+    type: ['integer', 'string', 'number', 'object', 'boolean'],
     description: 'Default value of property upon component creation. By default the property value is not defined.',
 };
 

--- a/lib/components-schema-v1_9_x.ts
+++ b/lib/components-schema-v1_9_x.ts
@@ -9,7 +9,7 @@
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 const defaultValue: JSONSchema7Definition = {
-    type: ['integer', 'string', 'number', 'object'],
+    type: ['integer', 'string', 'number', 'object', 'boolean'],
     description: 'Default value of property upon component creation. By default the property value is not defined.',
 };
 

--- a/lib/validators/default-values-validator.ts
+++ b/lib/validators/default-values-validator.ts
@@ -128,7 +128,7 @@ export class DefaultValuesValidator extends Validator {
      * Validate defaultValue for checkbox control type.
      */
     private validateCheckboxControlValue(property: ComponentProperty) {
-        if (!this.validateStringValue(property)) {
+        if (property.dataType !== 'data' && !this.validateStringValue(property)) {
             return;
         }
         if (property.defaultValue !== (<ComponentPropertyControlCheckbox>property.control).value) {

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -35,7 +35,7 @@ describe('validateFolder', () => {
     });
 
     it('should fail on sample with incorrect schema property', async () => {
-        jest.spyOn(global.console, 'log');
+        jest.spyOn(global.console, 'log').mockReturnValueOnce();
 
         expect(await validateFolder('./test/resources/minimal-sample-invalid-comp-property')).toBe(false);
         expect(global.console.log).toHaveBeenCalledWith(
@@ -55,7 +55,7 @@ components-definition.json - line 7, column 8:
     });
 
     it('should fail on sample with components definition missing', async () => {
-        jest.spyOn(global.console, 'log');
+        jest.spyOn(global.console, 'log').mockReturnValueOnce();
 
         expect(await validateFolder('./test/resources/missing-components-definition-sample')).toBe(false);
         expect(global.console.log).toHaveBeenCalledWith(
@@ -64,7 +64,7 @@ components-definition.json - line 7, column 8:
     });
 
     it('should fail on sample with invalid json', async () => {
-        jest.spyOn(global.console, 'log');
+        jest.spyOn(global.console, 'log').mockReturnValueOnce();
 
         expect(await validateFolder('./test/resources/invalid-definition-json-sample')).toBe(false);
         expect(global.console.log).toHaveBeenCalledWith(

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -124,8 +124,13 @@ describe('getValidators', () => {
         expect(validators && validators.length).toEqual(29);
     });
 
-    it('should return amount of validators for version >= 1.8.0-next', () => {
-        const validators = getValidators('1.8.0-next', <any>null, <any>null, <any>null, <any>null, <any>null);
+    it('should return amount of validators for version >= 1.8.0', () => {
+        const validators = getValidators('1.8.0', <any>null, <any>null, <any>null, <any>null, <any>null);
+        expect(validators && validators.length).toEqual(29);
+    });
+
+    it('should return amount of validators for version >= 1.9.0-next', () => {
+        const validators = getValidators('1.9.0-next', <any>null, <any>null, <any>null, <any>null, <any>null);
         expect(validators && validators.length).toEqual(29);
     });
 });

--- a/test/validators/default-values-validator.test.ts
+++ b/test/validators/default-values-validator.test.ts
@@ -198,6 +198,40 @@ describe('DefaultValuesValidator', () => {
         expect(error).toHaveBeenCalledWith('Property propertyName defaultValue does not match checkbox value');
     });
 
+    it('should pass with control type checkbox, data type data and boolean defaultValue', () => {
+        definition.components.text.properties.push({
+            name: 'propertyName',
+            defaultValue: true,
+            dataType: 'data',
+            control: {
+                type: 'checkbox',
+                value: true,
+            },
+        });
+
+        validator = new DefaultValuesValidator(error, definition);
+        validator.validate();
+
+        expect(error).not.toHaveBeenCalled();
+    });
+
+    it('should not pass with control type checkbox, data type other than data and boolean defaultValue', () => {
+        definition.components.text.properties.push({
+            name: 'propertyName',
+            defaultValue: true,
+            dataType: 'styles',
+            control: {
+                type: 'checkbox',
+                value: true,
+            },
+        });
+
+        validator = new DefaultValuesValidator(error, definition);
+        validator.validate();
+
+        expect(error).toHaveBeenCalledWith('Property propertyName defaultValue must be a string');
+    });
+
     it('should pass with control type drop-capital and defaultValue being a correct object', () => {
         definition.components.text.properties.push({
             name: 'propertyName',


### PR DESCRIPTION
For data type `data` it is now allowed to have a boolean defaultValue. We already allowed a boolean as value, but not for the defaultValue property. 

Also fixes two boyscouts:
- when switching from 1.8.0-next to 1.8.0 I forgot to change one test and add one another for 1.9.0-next
- disable console.error output for 3 tests