### PR TITLE
boyscout: restrict data type for new object-select property.

### DIFF
--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -49,6 +49,7 @@ export class PropertiesValidator extends Validator {
         this.validatePropertyName(property, componentPropertyNames, component);
         this.validateRadioPropertyIcons(property);
         this.validateCheckBoxValue(property);
+        this.validateObjectSelectDataType(property);
     }
 
     private validatePropertyName(
@@ -132,5 +133,16 @@ export class PropertiesValidator extends Validator {
                 this.validateProperty(childProperty, conditionalUsedPropertyNames, component);
             });
         });
+    }
+
+    private validateObjectSelectDataType(property: ComponentProperty) {
+        if (property.control.type !== 'object-select') {
+            return;
+        }
+        if (property.dataType !== 'data') {
+            this.error(
+                `Object select property "${property.name}" cannot use dataType "${property.dataType}", only dataType "data" is allowed`,
+            );
+        }
     }
 }

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -50,6 +50,19 @@ describe('PropertiesValidator', () => {
         } as any;
     }
 
+    function createObjectSelectProperty(): ComponentProperty {
+        return {
+            name: 'objectSelectProperty',
+            label: 'Object Select',
+            control: {
+                type: 'object-select',
+                source: 'dossier',
+                filterObjectTypes: ['Image'],
+            },
+            dataType: 'data',
+        };
+    }
+
     function createConditionalProperty(children: any[]) {
         return {
             name: 'conditionalProperty',
@@ -335,6 +348,32 @@ describe('PropertiesValidator', () => {
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
                 `Checkbox property "checkboxProperty" cannot have a boolean value for dataType "styles", boolean values are only allowed for dataType "data"`,
+            );
+        });
+    });
+
+    describe('object-select data type', () => {
+        it('should pass with dataType "data"', () => {
+            const prop = createObjectSelectProperty();
+            prop.dataType = 'data';
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.9.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not pass with dataType other than "data"', () => {
+            const prop = createObjectSelectProperty();
+            prop.dataType = 'styles';
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.9.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).toHaveBeenCalledWith(
+                `Object select property "objectSelectProperty" cannot use dataType "styles", only dataType "data" is allowed`,
             );
         });
     });


### PR DESCRIPTION
Doesn't make sense as "styles" or "inlineStyles", as in that case it will be added as styling to the dom. But the data is an object, so that would just result in weird behavior.