### PR TITLE
CSH-8707: introduce object data type.

### DIFF
--- a/lib/components-schema-v1_9_x.ts
+++ b/lib/components-schema-v1_9_x.ts
@@ -455,6 +455,7 @@ const componentPropertyDefinition: {
             'styles',
             'inlineStyles',
             'data',
+            'object',
             'doc-editable',
             'doc-image',
             'doc-html',

--- a/lib/components-schema-v1_9_x.ts
+++ b/lib/components-schema-v1_9_x.ts
@@ -421,7 +421,7 @@ const componentPropertyDefinition: {
                 required: ['type', 'source', 'filterObjectTypes'],
                 properties: {
                     type: {
-                        enum: ['object-select'],
+                        enum: ['studio-object-select'],
                         description:
                             'Experimental feature which allows the user to select an object as a component property. The object id is stored in the article data.',
                     },
@@ -455,7 +455,7 @@ const componentPropertyDefinition: {
             'styles',
             'inlineStyles',
             'data',
-            'object',
+            'studio-object',
             'doc-editable',
             'doc-image',
             'doc-html',

--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -318,7 +318,7 @@ export interface ComponentPropertyControlStudioObjectSelect {
     filterObjectTypes: 'Image'[];
     filterObjectFormats?: string[];
 }
-export function isObjectSelect(
+export function isStudioObjectSelect(
     control: ComponentPropertyControl,
 ): control is ComponentPropertyControlStudioObjectSelect {
     return control.type === 'studio-object-select';

--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -18,7 +18,7 @@ export type ComponentPropertyControl =
     | ComponentPropertyControlTextArea
     | ComponentPropertyControlUrl
     | ComponentPropertyControlSlider
-    | ComponentPropertyControlObjectSelect;
+    | ComponentPropertyControlStudioObjectSelect;
 
 /**
  * Dropdown with fixed number of options
@@ -310,16 +310,18 @@ export function isSlider(control: ComponentPropertyControl): control is Componen
 }
 
 /**
- * Object select field property
+ * Studio Object select field property
  */
-export interface ComponentPropertyControlObjectSelect {
-    type: 'object-select';
+export interface ComponentPropertyControlStudioObjectSelect {
+    type: 'studio-object-select';
     source: 'dossier';
     filterObjectTypes: 'Image'[];
     filterObjectFormats?: string[];
 }
-export function isObjectSelect(control: ComponentPropertyControl): control is ComponentPropertyControlObjectSelect {
-    return control.type === 'object-select';
+export function isObjectSelect(
+    control: ComponentPropertyControl,
+): control is ComponentPropertyControlStudioObjectSelect {
+    return control.type === 'studio-object-select';
 }
 
 /**

--- a/lib/models/components-definition.ts
+++ b/lib/models/components-definition.ts
@@ -148,6 +148,7 @@ export interface ComponentProperty<ControlType = ComponentPropertyControl> {
         | 'styles'
         | 'inlineStyles'
         | 'data'
+        | 'object'
         | 'doc-editable'
         | 'doc-image'
         | 'doc-html'

--- a/lib/models/components-definition.ts
+++ b/lib/models/components-definition.ts
@@ -148,7 +148,7 @@ export interface ComponentProperty<ControlType = ComponentPropertyControl> {
         | 'styles'
         | 'inlineStyles'
         | 'data'
-        | 'object'
+        | 'studio-object'
         | 'doc-editable'
         | 'doc-image'
         | 'doc-html'

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -26,7 +26,7 @@ const TYPES_ALLOWING_CHILD_PROPERTIES: ComponentPropertyControl['type'][] = [
     'slider',
 ];
 
-const ALLOWED_CONTROL_TYPES_FOR_OBJECT_DATA_TYPE: ComponentPropertyControl['type'][] = ['object-select'];
+const ALLOWED_CONTROL_TYPES_FOR_OBJECT_DATA_TYPE: ComponentPropertyControl['type'][] = ['studio-object-select'];
 
 export class PropertiesValidator extends Validator {
     constructor(error: (errorMessage: string) => false, definition: ComponentSet, protected filePaths: Set<string>) {
@@ -139,10 +139,10 @@ export class PropertiesValidator extends Validator {
     }
 
     private validateObjectSelectDataType(property: ComponentProperty) {
-        if (property.control.type !== 'object-select') {
+        if (property.control.type !== 'studio-object-select') {
             return;
         }
-        if (property.dataType !== 'object') {
+        if (property.dataType !== 'studio-object') {
             this.error(
                 `Object select property "${property.name}" cannot use dataType "${property.dataType}", only dataType "object" is allowed`,
             );
@@ -150,7 +150,7 @@ export class PropertiesValidator extends Validator {
     }
 
     private validateObjectDataType(property: ComponentProperty) {
-        if (property.dataType !== 'object') {
+        if (property.dataType !== 'studio-object') {
             return;
         }
         if (!ALLOWED_CONTROL_TYPES_FOR_OBJECT_DATA_TYPE.includes(property.control.type)) {

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -26,6 +26,8 @@ const TYPES_ALLOWING_CHILD_PROPERTIES: ComponentPropertyControl['type'][] = [
     'slider',
 ];
 
+const ALLOWED_CONTROL_TYPES_FOR_OBJECT_DATA_TYPE: ComponentPropertyControl['type'][] = ['object-select'];
+
 export class PropertiesValidator extends Validator {
     constructor(error: (errorMessage: string) => false, definition: ComponentSet, protected filePaths: Set<string>) {
         super(error, definition);
@@ -49,6 +51,7 @@ export class PropertiesValidator extends Validator {
         this.validatePropertyName(property, componentPropertyNames, component);
         this.validateRadioPropertyIcons(property);
         this.validateCheckBoxValue(property);
+        this.validateObjectDataType(property);
         this.validateObjectSelectDataType(property);
     }
 
@@ -139,10 +142,19 @@ export class PropertiesValidator extends Validator {
         if (property.control.type !== 'object-select') {
             return;
         }
-        if (property.dataType !== 'data') {
+        if (property.dataType !== 'object') {
             this.error(
-                `Object select property "${property.name}" cannot use dataType "${property.dataType}", only dataType "data" is allowed`,
+                `Object select property "${property.name}" cannot use dataType "${property.dataType}", only dataType "object" is allowed`,
             );
+        }
+    }
+
+    private validateObjectDataType(property: ComponentProperty) {
+        if (property.dataType !== 'object') {
+            return;
+        }
+        if (!ALLOWED_CONTROL_TYPES_FOR_OBJECT_DATA_TYPE.includes(property.control.type)) {
+            this.error(`Cannot use dataType "object" with control type "${property.control.type}"`);
         }
     }
 }

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -26,7 +26,7 @@ const TYPES_ALLOWING_CHILD_PROPERTIES: ComponentPropertyControl['type'][] = [
     'slider',
 ];
 
-const ALLOWED_CONTROL_TYPES_FOR_OBJECT_DATA_TYPE: ComponentPropertyControl['type'][] = ['studio-object-select'];
+const ALLOWED_CONTROL_TYPES_FOR_STUDIO_OBJECT_DATA_TYPE: ComponentPropertyControl['type'][] = ['studio-object-select'];
 
 export class PropertiesValidator extends Validator {
     constructor(error: (errorMessage: string) => false, definition: ComponentSet, protected filePaths: Set<string>) {
@@ -51,8 +51,8 @@ export class PropertiesValidator extends Validator {
         this.validatePropertyName(property, componentPropertyNames, component);
         this.validateRadioPropertyIcons(property);
         this.validateCheckBoxValue(property);
-        this.validateObjectDataType(property);
-        this.validateObjectSelectDataType(property);
+        this.validateStudioObjectDataType(property);
+        this.validateStudioObjectSelectDataType(property);
     }
 
     private validatePropertyName(
@@ -138,23 +138,23 @@ export class PropertiesValidator extends Validator {
         });
     }
 
-    private validateObjectSelectDataType(property: ComponentProperty) {
+    private validateStudioObjectSelectDataType(property: ComponentProperty) {
         if (property.control.type !== 'studio-object-select') {
             return;
         }
         if (property.dataType !== 'studio-object') {
             this.error(
-                `Object select property "${property.name}" cannot use dataType "${property.dataType}", only dataType "object" is allowed`,
+                `Object select property "${property.name}" cannot use dataType "${property.dataType}", only dataType "studio-object" is allowed`,
             );
         }
     }
 
-    private validateObjectDataType(property: ComponentProperty) {
+    private validateStudioObjectDataType(property: ComponentProperty) {
         if (property.dataType !== 'studio-object') {
             return;
         }
-        if (!ALLOWED_CONTROL_TYPES_FOR_OBJECT_DATA_TYPE.includes(property.control.type)) {
-            this.error(`Cannot use dataType "object" with control type "${property.control.type}"`);
+        if (!ALLOWED_CONTROL_TYPES_FOR_STUDIO_OBJECT_DATA_TYPE.includes(property.control.type)) {
+            this.error(`Cannot use dataType "studio-object" with control type "${property.control.type}"`);
         }
     }
 }

--- a/test/resources/minimal-sample-next/components-definition.json
+++ b/test/resources/minimal-sample-next/components-definition.json
@@ -183,7 +183,7 @@
                 "filterObjectTypes": ["Image"],
                 "filterObjectFormats": ["image/jpeg"]
             },
-            "dataType": "data"
+            "dataType": "object"
         }
     ],
     "conversionRules": {

--- a/test/resources/minimal-sample-next/components-definition.json
+++ b/test/resources/minimal-sample-next/components-definition.json
@@ -178,12 +178,12 @@
             "name": "background-image",
             "label": "Background-image",
             "control": {
-                "type": "object-select",
+                "type": "studio-object-select",
                 "source": "dossier",
                 "filterObjectTypes": ["Image"],
                 "filterObjectFormats": ["image/jpeg"]
             },
-            "dataType": "object"
+            "dataType": "studio-object"
         }
     ],
     "conversionRules": {

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -75,7 +75,7 @@ describe('validateFolder', () => {
         expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('/characterStyles/0/id must match pattern'));
     });
 
-    it('should fail on invalid object-select property', async () => {
+    it('should fail on invalid studio-object-select property', async () => {
         const { validateFolderWithCustomiser, errorSpy } = createValidator((filePath: string, content: string) => {
             if (filePath === 'components-definition.json') {
                 const componentsDefinition = JSON.parse(content);

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -55,11 +55,11 @@ describe('PropertiesValidator', () => {
             name: 'objectSelectProperty',
             label: 'Object Select',
             control: {
-                type: 'object-select',
+                type: 'studio-object-select',
                 source: 'dossier',
                 filterObjectTypes: ['Image'],
             },
-            dataType: 'object',
+            dataType: 'studio-object',
         };
     }
 
@@ -355,7 +355,7 @@ describe('PropertiesValidator', () => {
     describe('object data type', () => {
         it('should pass with dataType "object"', () => {
             const prop = createObjectSelectProperty();
-            prop.dataType = 'object';
+            prop.dataType = 'studio-object';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.9.0',
                 properties: [prop],
@@ -379,7 +379,7 @@ describe('PropertiesValidator', () => {
 
         it('should not be able to use with regular property controls like text', () => {
             const prop = createTextProperty();
-            prop.dataType = 'object';
+            prop.dataType = 'studio-object';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.9.0',
                 properties: [prop],

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -50,7 +50,7 @@ describe('PropertiesValidator', () => {
         } as any;
     }
 
-    function createObjectSelectProperty(): ComponentProperty {
+    function createStudioObjectSelectProperty(): ComponentProperty {
         return {
             name: 'objectSelectProperty',
             label: 'Object Select',
@@ -352,9 +352,9 @@ describe('PropertiesValidator', () => {
         });
     });
 
-    describe('object data type', () => {
-        it('should pass with dataType "object"', () => {
-            const prop = createObjectSelectProperty();
+    describe('studio object data type', () => {
+        it('should pass with dataType "studio-object"', () => {
+            const prop = createStudioObjectSelectProperty();
             prop.dataType = 'studio-object';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.9.0',
@@ -364,8 +364,8 @@ describe('PropertiesValidator', () => {
             expect(errorSpy).not.toHaveBeenCalled();
         });
 
-        it('should not pass with dataType other than "object"', () => {
-            const prop = createObjectSelectProperty();
+        it('should not pass with dataType other than "studio-object"', () => {
+            const prop = createStudioObjectSelectProperty();
             prop.dataType = 'data';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.9.0',
@@ -373,7 +373,7 @@ describe('PropertiesValidator', () => {
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
-                `Object select property "objectSelectProperty" cannot use dataType "data", only dataType "object" is allowed`,
+                `Object select property "objectSelectProperty" cannot use dataType "data", only dataType "studio-object" is allowed`,
             );
         });
 
@@ -385,7 +385,7 @@ describe('PropertiesValidator', () => {
                 properties: [prop],
             });
             validator.validate();
-            expect(errorSpy).toHaveBeenCalledWith(`Cannot use dataType "object" with control type "text"`);
+            expect(errorSpy).toHaveBeenCalledWith(`Cannot use dataType "studio-object" with control type "text"`);
         });
     });
 });

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -59,7 +59,7 @@ describe('PropertiesValidator', () => {
                 source: 'dossier',
                 filterObjectTypes: ['Image'],
             },
-            dataType: 'data',
+            dataType: 'object',
         };
     }
 
@@ -352,10 +352,10 @@ describe('PropertiesValidator', () => {
         });
     });
 
-    describe('object-select data type', () => {
-        it('should pass with dataType "data"', () => {
+    describe('object data type', () => {
+        it('should pass with dataType "object"', () => {
             const prop = createObjectSelectProperty();
-            prop.dataType = 'data';
+            prop.dataType = 'object';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.9.0',
                 properties: [prop],
@@ -364,17 +364,28 @@ describe('PropertiesValidator', () => {
             expect(errorSpy).not.toHaveBeenCalled();
         });
 
-        it('should not pass with dataType other than "data"', () => {
+        it('should not pass with dataType other than "object"', () => {
             const prop = createObjectSelectProperty();
-            prop.dataType = 'styles';
+            prop.dataType = 'data';
             const { validator, errorSpy } = createPropertiesValidator({
                 version: '1.9.0',
                 properties: [prop],
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(
-                `Object select property "objectSelectProperty" cannot use dataType "styles", only dataType "data" is allowed`,
+                `Object select property "objectSelectProperty" cannot use dataType "data", only dataType "object" is allowed`,
             );
+        });
+
+        it('should not be able to use with regular property controls like text', () => {
+            const prop = createTextProperty();
+            prop.dataType = 'object';
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.9.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).toHaveBeenCalledWith(`Cannot use dataType "object" with control type "text"`);
         });
     });
 });


### PR DESCRIPTION
This is used to indicate the data refers to an object in Studio.
When a property is created with this data type, it ensures placed relations are created with that object.
For now it can only be used with the experimental "object-select" UI control type.
Archiving to assets is not supported (the image will not be picked up).