### PR TITLE
boyscout: fix schema version too strict for 1.9.0

### DIFF
--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -280,7 +280,7 @@ function getValidationSchemaSource(version: string): Schema | null {
         return componentsDefinitionSchema_v1_7_x;
     } else if (semver.satisfies(version, '1.8.x', semVerOptions)) {
         return componentsDefinitionSchema_v1_8_x;
-    } else if (semver.satisfies(version, '1.9.0', semVerOptions)) {
+    } else if (semver.satisfies(version, '1.9.x', semVerOptions)) {
         return componentsDefinitionSchema_v1_9_x;
     } else if (semver.satisfies(version, '1.10.0-next', semVerOptions)) {
         return componentsDefinitionSchema_v1_10_x;


### PR DESCRIPTION
Will check in a separate PR how to improve the tests. So we need some unit tests that try different combinations. With the previous code "1.9.0-next" was no longer valid...