### PR TITLE
CSH-8877: Add component property info to the partial info definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ The returned data contains the field information per component. An example of th
             ],
         },
     },
+    componentProperties: {
+        position: {
+            dataType: 'styles',
+        },
+        'line-height': {
+            dataType: 'inlineStyles',
+        },
+    },
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ The returned data contains the field information per component. An example of th
                     type: 'editable',
                 },
             ],
+            properties: [
+                {
+                    name: 'position',
+                    dataType: 'styles',
+                },
+                {
+                    name: 'line-height',
+                    dataType: 'inlineStyles',
+                },
+            ]
         },
         container: {
             fields: [
@@ -101,14 +111,7 @@ The returned data contains the field information per component. An example of th
                     type: 'container',
                 },
             ],
-        },
-    },
-    componentProperties: {
-        position: {
-            dataType: 'styles',
-        },
-        'line-height': {
-            dataType: 'inlineStyles',
+            properties: [],
         },
     },
 }

--- a/lib/definition/component-info.ts
+++ b/lib/definition/component-info.ts
@@ -35,8 +35,8 @@ export async function generateComponentSetInfo(
  *
  * This implementation can be used when the components definition already contains the rendition information.
  */
-export function processInfo(componentsDefinition: ComponentsDefinition): ComponentSetInfo {
-    const componentSet = parseDefinition(componentsDefinition);
+export async function processInfo(componentsDefinition: ComponentsDefinition): Promise<ComponentSetInfo> {
+    const componentSet = await parseDefinition(componentsDefinition);
     return {
         components: Object.values(componentSet.components).reduce((result, component) => {
             result[component.name] = {

--- a/lib/definition/component-info.ts
+++ b/lib/definition/component-info.ts
@@ -113,7 +113,6 @@ function parseProperties(properties: ComponentProperty[]) {
             infoProperties.push({
                 name: property.name,
                 dataType: property.dataType,
-                ...(typeof property.label === 'string' && { label: property.label }),
             });
         }
         return infoProperties;

--- a/lib/definition/component-info.ts
+++ b/lib/definition/component-info.ts
@@ -8,7 +8,7 @@ import {
     ComponentField,
     ComponentSetInfo,
     ComponentInfoFields,
-    ComponentInfoProperty,
+    ComponentInfoProperties,
 } from '../models/component-set-info';
 import { RenditionResolver, processTemplates } from './process-templates';
 import parse5 = require('parse5');
@@ -110,11 +110,10 @@ function addRestrictChildrenInfo(
 function parseProperties(properties: ComponentProperty[]) {
     return properties.reduce((infoProperties, property) => {
         if (property.control.type !== 'header') {
-            infoProperties.push({
-                name: property.name,
+            infoProperties[property.name] = {
                 dataType: property.dataType,
-            });
+            };
         }
         return infoProperties;
-    }, [] as ComponentInfoProperty[]);
+    }, {} as ComponentInfoProperties);
 }

--- a/lib/definition/component-info.ts
+++ b/lib/definition/component-info.ts
@@ -109,8 +109,12 @@ function addRestrictChildrenInfo(
 
 function parseProperties(properties: ComponentProperty[]) {
     return properties.reduce((infoProperties, property) => {
-        if (property.name) {
-            infoProperties.push({ name: property.name, dataType: property.dataType });
+        if (property.control.type !== 'header') {
+            infoProperties.push({
+                name: property.name,
+                dataType: property.dataType,
+                ...(typeof property.label === 'string' && { label: property.label }),
+            });
         }
         return infoProperties;
     }, [] as ComponentInfoProperty[]);

--- a/lib/definition/component-info.ts
+++ b/lib/definition/component-info.ts
@@ -1,5 +1,10 @@
 import { ComponentsDefinition, ComponentDefinition, ComponentRendition } from '../models/components-definition';
-import { ComponentField, ComponentSetInfo, ComponentInfoFields } from '../models/component-set-info';
+import {
+    ComponentField,
+    ComponentSetInfo,
+    ComponentInfoFields,
+    ComponentInfoProperties,
+} from '../models/component-set-info';
 import { RenditionResolver, processTemplates } from './process-templates';
 import parse5 = require('parse5');
 
@@ -33,6 +38,12 @@ export function processInfo(componentsDefinition: ComponentsDefinition): Compone
             result[component.name].fields.forEach((f) => addRestrictChildrenInfo(componentsDefinition, component, f));
             return result;
         }, {} as ComponentInfoFields),
+        componentProperties: componentsDefinition.componentProperties.reduce((result, property) => {
+            result[property.name] = {
+                dataType: property.dataType,
+            };
+            return result;
+        }, {} as ComponentInfoProperties),
     };
 }
 

--- a/lib/models/component-set-info.ts
+++ b/lib/models/component-set-info.ts
@@ -1,14 +1,16 @@
+import { ComponentPropertyDataType } from '.';
+
 /**
  * Simplified component set information, used by custom channel consumers to easily interpret articles.
  */
 export interface ComponentSetInfo {
     components: ComponentInfoFields;
-    componentProperties: ComponentInfoProperties;
 }
 
 export interface ComponentInfoFields {
     [component: string]: {
         fields: ComponentField[];
+        properties: ComponentInfoProperty[];
     };
 }
 
@@ -18,8 +20,7 @@ export interface ComponentField {
     restrictChildren?: string[];
 }
 
-export interface ComponentInfoProperties {
-    [property: string]: {
-        dataType: string;
-    };
+export interface ComponentInfoProperty {
+    name: string;
+    dataType: ComponentPropertyDataType;
 }

--- a/lib/models/component-set-info.ts
+++ b/lib/models/component-set-info.ts
@@ -1,27 +1,16 @@
 /**
- * Combines information about component related fields.
- * Example:
- * {
- *   body: {
-
- *      fields: [
- *          {
- *              type: "editable",
- *              contentKey: "text"
- *          }
- *     ]
- *   },
- *   title: {
- *      fields:    [
- *          {
- *              type: "editable",
- *              contentKey: "text"
- *          }
- *      ]
- *   }
- *   ... etc ...
- * }
+ * Simplified component set information, used by custom channel consumers to easily interpret articles.
  */
+export interface ComponentSetInfo {
+    components: ComponentInfoFields;
+    componentProperties: ComponentInfoProperties;
+}
+
+export interface ComponentInfoFields {
+    [component: string]: {
+        fields: ComponentField[];
+    };
+}
 
 export interface ComponentField {
     contentKey: string;
@@ -29,15 +18,8 @@ export interface ComponentField {
     restrictChildren?: string[];
 }
 
-/**
- * Simplified component set information, used by custom channel consumers to easily interpret articles.
- */
-export interface ComponentSetInfo {
-    components: ComponentInfoFields;
-}
-
-export interface ComponentInfoFields {
-    [component: string]: {
-        fields: ComponentField[];
+export interface ComponentInfoProperties {
+    [property: string]: {
+        dataType: string;
     };
 }

--- a/lib/models/component-set-info.ts
+++ b/lib/models/component-set-info.ts
@@ -10,7 +10,7 @@ export interface ComponentSetInfo {
 export interface ComponentInfoFields {
     [component: string]: {
         fields: ComponentField[];
-        properties: ComponentInfoProperty[];
+        properties: ComponentInfoProperties;
     };
 }
 
@@ -20,7 +20,8 @@ export interface ComponentField {
     restrictChildren?: string[];
 }
 
-export interface ComponentInfoProperty {
-    name: string;
-    dataType: ComponentPropertyDataType;
+export interface ComponentInfoProperties {
+    [property: string]: {
+        dataType: ComponentPropertyDataType;
+    };
 }

--- a/lib/models/components-definition.ts
+++ b/lib/models/components-definition.ts
@@ -131,6 +131,19 @@ export enum ComponentRendition {
     PSV = 'psv',
 }
 
+export type ComponentPropertyDataType =
+    | 'styles'
+    | 'inlineStyles'
+    | 'data'
+    | 'studio-object'
+    | 'doc-editable'
+    | 'doc-image'
+    | 'doc-html'
+    | 'doc-slideshow'
+    | 'doc-media'
+    | 'doc-interactive'
+    | 'doc-link';
+
 export interface ComponentProperty<ControlType = ComponentPropertyControl> {
     /** Unique identifier of component property */
     name: string;
@@ -144,18 +157,7 @@ export interface ComponentProperty<ControlType = ComponentPropertyControl> {
     control: ControlType;
 
     /** Type of data being stored and how it is used. For directive data types it may also depend on the control type. */
-    dataType:
-        | 'styles'
-        | 'inlineStyles'
-        | 'data'
-        | 'studio-object'
-        | 'doc-editable'
-        | 'doc-image'
-        | 'doc-html'
-        | 'doc-slideshow'
-        | 'doc-media'
-        | 'doc-interactive'
-        | 'doc-link';
+    dataType: ComponentPropertyDataType;
 
     /** Default value of property upon component creation. By default the property value is not defined. */
     defaultValue?: string | { [key: string]: unknown } | number;

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -22,7 +22,7 @@ import {
  * - that group names are unique
  * - that components have at least an HTML rendition
  */
-export function parseDefinition(componentsDefinition: ComponentsDefinition): ComponentSet {
+export async function parseDefinition(componentsDefinition: ComponentsDefinition): Promise<ComponentSet> {
     const componentSet: ComponentSet = {
         name: componentsDefinition.name,
         description: componentsDefinition.description,

--- a/lib/parser/parser-utils.ts
+++ b/lib/parser/parser-utils.ts
@@ -22,7 +22,7 @@ import {
  * - that group names are unique
  * - that components have at least an HTML rendition
  */
-export async function parseDefinition(componentsDefinition: ComponentsDefinition): Promise<ComponentSet> {
+export function parseDefinition(componentsDefinition: ComponentsDefinition): ComponentSet {
     const componentSet: ComponentSet = {
         name: componentsDefinition.name,
         description: componentsDefinition.description,

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -174,7 +174,7 @@ export async function validate(
     // parse everything for deeper testing
     let componentSet: ComponentSet | null = null;
     try {
-        componentSet = parseDefinition(await loadHtmlRenditions(componentsDefinition, getFileContent));
+        componentSet = await parseDefinition(await loadHtmlRenditions(componentsDefinition, getFileContent));
     } catch (e) {
         if (!(e instanceof Error)) {
             // Re-throw any non Error objects as these should not happen (software error, not a component set issue)

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -174,9 +174,13 @@ export async function validate(
     // parse everything for deeper testing
     let componentSet: ComponentSet | null = null;
     try {
-        componentSet = await parseDefinition(await loadHtmlRenditions(componentsDefinition, getFileContent));
+        componentSet = parseDefinition(await loadHtmlRenditions(componentsDefinition, getFileContent));
     } catch (e) {
-        errorReporter(e.message ?? e);
+        if (!(e instanceof Error)) {
+            // Re-throw any non Error objects as these should not happen (software error, not a component set issue)
+            throw e;
+        }
+        errorReporter(e.message);
     }
     // can't run validators if the parser has failed
     if (!componentSet) {

--- a/test/definition/component-info.test.ts
+++ b/test/definition/component-info.test.ts
@@ -43,12 +43,11 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'selectProperty',
+                        properties: {
+                            selectProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                     intro: {
                         fields: [
@@ -57,12 +56,11 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'checkboxProperty',
+                        properties: {
+                            checkboxProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                 },
             });
@@ -80,12 +78,11 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'selectProperty',
+                        properties: {
+                            selectProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                     intro: {
                         fields: [
@@ -94,12 +91,11 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'checkboxProperty',
+                        properties: {
+                            checkboxProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                 },
             });
@@ -112,21 +108,19 @@ describe('ComponentInfo', () => {
                 components: {
                     body: {
                         fields: [],
-                        properties: [
-                            {
-                                name: 'selectProperty',
+                        properties: {
+                            selectProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                     intro: {
                         fields: [],
-                        properties: [
-                            {
-                                name: 'checkboxProperty',
+                        properties: {
+                            checkboxProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                 },
             });
@@ -169,12 +163,11 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'edit-image',
+                        properties: {
+                            'edit-image': {
                                 dataType: 'doc-image',
                             },
-                        ],
+                        },
                     },
                     slideshow: {
                         fields: [
@@ -183,12 +176,11 @@ describe('ComponentInfo', () => {
                                 type: 'slideshow',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'slides',
+                        properties: {
+                            slides: {
                                 dataType: 'doc-slideshow',
                             },
-                        ],
+                        },
                     },
                     body: {
                         fields: [
@@ -197,12 +189,11 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'selectProperty',
+                        properties: {
+                            selectProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                     intro: {
                         fields: [
@@ -211,12 +202,11 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                        properties: [
-                            {
-                                name: 'checkboxProperty',
+                        properties: {
+                            checkboxProperty: {
                                 dataType: 'styles',
                             },
-                        ],
+                        },
                     },
                     container: {
                         fields: [
@@ -226,7 +216,7 @@ describe('ComponentInfo', () => {
                                 type: 'container',
                             },
                         ],
-                        properties: [],
+                        properties: {},
                     },
                     container2: {
                         fields: [
@@ -236,7 +226,7 @@ describe('ComponentInfo', () => {
                                 type: 'container',
                             },
                         ],
-                        properties: [],
+                        properties: {},
                     },
                 },
             });

--- a/test/definition/component-info.test.ts
+++ b/test/definition/component-info.test.ts
@@ -43,6 +43,12 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
+                        properties: [
+                            {
+                                name: 'selectProperty',
+                                dataType: 'styles',
+                            },
+                        ],
                     },
                     intro: {
                         fields: [
@@ -51,14 +57,12 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                    },
-                },
-                componentProperties: {
-                    checkboxProperty: {
-                        dataType: 'styles',
-                    },
-                    selectProperty: {
-                        dataType: 'styles',
+                        properties: [
+                            {
+                                name: 'checkboxProperty',
+                                dataType: 'styles',
+                            },
+                        ],
                     },
                 },
             });
@@ -76,6 +80,12 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
+                        properties: [
+                            {
+                                name: 'selectProperty',
+                                dataType: 'styles',
+                            },
+                        ],
                     },
                     intro: {
                         fields: [
@@ -84,14 +94,12 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
-                    },
-                },
-                componentProperties: {
-                    checkboxProperty: {
-                        dataType: 'styles',
-                    },
-                    selectProperty: {
-                        dataType: 'styles',
+                        properties: [
+                            {
+                                name: 'checkboxProperty',
+                                dataType: 'styles',
+                            },
+                        ],
                     },
                 },
             });
@@ -104,17 +112,21 @@ describe('ComponentInfo', () => {
                 components: {
                     body: {
                         fields: [],
+                        properties: [
+                            {
+                                name: 'selectProperty',
+                                dataType: 'styles',
+                            },
+                        ],
                     },
                     intro: {
                         fields: [],
-                    },
-                },
-                componentProperties: {
-                    checkboxProperty: {
-                        dataType: 'styles',
-                    },
-                    selectProperty: {
-                        dataType: 'styles',
+                        properties: [
+                            {
+                                name: 'checkboxProperty',
+                                dataType: 'styles',
+                            },
+                        ],
                     },
                 },
             });
@@ -157,12 +169,24 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
+                        properties: [
+                            {
+                                name: 'edit-image',
+                                dataType: 'doc-image',
+                            },
+                        ],
                     },
                     slideshow: {
                         fields: [
                             {
                                 contentKey: 'slideshow',
                                 type: 'slideshow',
+                            },
+                        ],
+                        properties: [
+                            {
+                                name: 'slides',
+                                dataType: 'doc-slideshow',
                             },
                         ],
                     },
@@ -173,12 +197,24 @@ describe('ComponentInfo', () => {
                                 type: 'editable',
                             },
                         ],
+                        properties: [
+                            {
+                                name: 'selectProperty',
+                                dataType: 'styles',
+                            },
+                        ],
                     },
                     intro: {
                         fields: [
                             {
                                 contentKey: 'text',
                                 type: 'editable',
+                            },
+                        ],
+                        properties: [
+                            {
+                                name: 'checkboxProperty',
+                                dataType: 'styles',
                             },
                         ],
                     },
@@ -190,6 +226,7 @@ describe('ComponentInfo', () => {
                                 type: 'container',
                             },
                         ],
+                        properties: [],
                     },
                     container2: {
                         fields: [
@@ -199,20 +236,7 @@ describe('ComponentInfo', () => {
                                 type: 'container',
                             },
                         ],
-                    },
-                },
-                componentProperties: {
-                    checkboxProperty: {
-                        dataType: 'styles',
-                    },
-                    selectProperty: {
-                        dataType: 'styles',
-                    },
-                    'edit-image': {
-                        dataType: 'doc-image',
-                    },
-                    slides: {
-                        dataType: 'doc-slideshow',
+                        properties: [],
                     },
                 },
             });

--- a/test/definition/component-info.test.ts
+++ b/test/definition/component-info.test.ts
@@ -71,7 +71,7 @@ describe('ComponentInfo', () => {
         it('should return the component set information data when using processInfo', async () => {
             await processTemplatesFromZip();
 
-            expect(processInfo(definition)).toEqual({
+            expect(await processInfo(definition)).toEqual({
                 components: {
                     body: {
                         fields: [
@@ -108,7 +108,7 @@ describe('ComponentInfo', () => {
         it('should return the component set info for empty templates', async () => {
             await processEmptyTemplates();
 
-            expect(processInfo(definition)).toEqual({
+            expect(await processInfo(definition)).toEqual({
                 components: {
                     body: {
                         fields: [],

--- a/test/definition/component-info.test.ts
+++ b/test/definition/component-info.test.ts
@@ -53,6 +53,14 @@ describe('ComponentInfo', () => {
                         ],
                     },
                 },
+                componentProperties: {
+                    checkboxProperty: {
+                        dataType: 'styles',
+                    },
+                    selectProperty: {
+                        dataType: 'styles',
+                    },
+                },
             });
         });
 
@@ -78,6 +86,14 @@ describe('ComponentInfo', () => {
                         ],
                     },
                 },
+                componentProperties: {
+                    checkboxProperty: {
+                        dataType: 'styles',
+                    },
+                    selectProperty: {
+                        dataType: 'styles',
+                    },
+                },
             });
         });
 
@@ -91,6 +107,14 @@ describe('ComponentInfo', () => {
                     },
                     intro: {
                         fields: [],
+                    },
+                },
+                componentProperties: {
+                    checkboxProperty: {
+                        dataType: 'styles',
+                    },
+                    selectProperty: {
+                        dataType: 'styles',
                     },
                 },
             });
@@ -175,6 +199,20 @@ describe('ComponentInfo', () => {
                                 type: 'container',
                             },
                         ],
+                    },
+                },
+                componentProperties: {
+                    checkboxProperty: {
+                        dataType: 'styles',
+                    },
+                    selectProperty: {
+                        dataType: 'styles',
+                    },
+                    'edit-image': {
+                        dataType: 'doc-image',
+                    },
+                    slides: {
+                        dataType: 'doc-slideshow',
                     },
                 },
             });

--- a/test/definition/process-templates.test.ts
+++ b/test/definition/process-templates.test.ts
@@ -41,7 +41,7 @@ describe('Process Templates', () => {
                         key: 'INTRO_KEY',
                     },
                     name: 'intro',
-                    properties: ['checkboxProperty'],
+                    properties: [{ control: { type: 'header' }, label: 'header' }, 'checkboxProperty'],
                     renditions: {
                         html: `<p class="intro" doc-editable="text">Placeholder text</p>\n`,
                         psv: '',
@@ -73,7 +73,7 @@ describe('Process Templates', () => {
                         key: 'INTRO_KEY',
                     },
                     name: 'intro',
-                    properties: ['checkboxProperty'],
+                    properties: [{ control: { type: 'header' }, label: 'header' }, 'checkboxProperty'],
                     renditions: {
                         html: '',
                         psv: '',

--- a/test/resources/minimal-sample/components-definition.json
+++ b/test/resources/minimal-sample/components-definition.json
@@ -18,7 +18,15 @@
                 "key": "INTRO_KEY"
             },
             "icon": "icons/component.svg",
-            "properties": ["checkboxProperty"]
+            "properties": [
+                {
+                    "control": {
+                        "type": "header"
+                    },
+                    "label": "header"
+                },
+                "checkboxProperty"
+            ]
         }
     ],
 


### PR DESCRIPTION
Information will be used in the Studio plug-in while parsing the article to find all `studio-object-select` properties.