### PR TITLE
Feature/csh 9204 anchor property type

### DIFF
--- a/lib/components-schema-v1_10_x.ts
+++ b/lib/components-schema-v1_10_x.ts
@@ -497,7 +497,7 @@ const componentPropertyDefinition: {
                 matchType: {
                     type: 'string',
                     description: `Defines how to match the value of the parent property`,
-                    enum: ['exact-value'],
+                    enum: ['exact-value', 'any-value'],
                 },
                 matchExpression: {
                     type: ['boolean', 'integer', 'string', 'number'],

--- a/lib/components-schema-v1_10_x.ts
+++ b/lib/components-schema-v1_10_x.ts
@@ -448,6 +448,17 @@ const componentPropertyDefinition: {
                     },
                 },
             },
+            {
+                additionalProperties: false,
+                required: ['type'],
+                properties: {
+                    type: {
+                        enum: ['anchor'],
+                        description:
+                            'Experimental feature which allows the user to select text and anchor it to other components.',
+                    },
+                },
+            },
         ],
     },
     dataType: {

--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -18,7 +18,8 @@ export type ComponentPropertyControl =
     | ComponentPropertyControlTextArea
     | ComponentPropertyControlUrl
     | ComponentPropertyControlSlider
-    | ComponentPropertyControlStudioObjectSelect;
+    | ComponentPropertyControlStudioObjectSelect
+    | ComponentPropertyControlAnchor;
 
 /**
  * Dropdown with fixed number of options
@@ -322,6 +323,16 @@ export function isStudioObjectSelect(
     control: ComponentPropertyControl,
 ): control is ComponentPropertyControlStudioObjectSelect {
     return control.type === 'studio-object-select';
+}
+
+/**
+ * Anchor field property
+ */
+export interface ComponentPropertyControlAnchor {
+    type: 'anchor';
+}
+export function isAnchor(control: ComponentPropertyControl): control is ComponentPropertyControlAnchor {
+    return control.type === 'anchor';
 }
 
 /**

--- a/lib/validators/properties-validator.ts
+++ b/lib/validators/properties-validator.ts
@@ -24,6 +24,7 @@ const TYPES_ALLOWING_CHILD_PROPERTIES: ComponentPropertyControl['type'][] = [
     'time',
     'colorPicker',
     'slider',
+    'anchor',
 ];
 
 const ALLOWED_CONTROL_TYPES_FOR_STUDIO_OBJECT_DATA_TYPE: ComponentPropertyControl['type'][] = ['studio-object-select'];
@@ -53,6 +54,7 @@ export class PropertiesValidator extends Validator {
         this.validateCheckBoxValue(property);
         this.validateStudioObjectDataType(property);
         this.validateStudioObjectSelectDataType(property);
+        this.validateAnchorDataType(property);
     }
 
     private validatePropertyName(
@@ -145,6 +147,17 @@ export class PropertiesValidator extends Validator {
         if (property.dataType !== 'studio-object') {
             this.error(
                 `Object select property "${property.name}" cannot use dataType "${property.dataType}", only dataType "studio-object" is allowed`,
+            );
+        }
+    }
+
+    private validateAnchorDataType(property: ComponentProperty) {
+        if (property.control.type !== 'anchor') {
+            return;
+        }
+        if (property.dataType !== 'data') {
+            this.error(
+                `Anchor property "${property.name}" cannot use dataType "${property.dataType}", only dataType "data" is allowed`,
             );
         }
     }

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+import { validate, readFile, getSize } from '../lib/validate';
+import { listFilesRelativeToFolder } from '../lib/util/files';
+import { GetFileContentOptionsType } from '../lib/models';
+
+export function createValidator(fileCustomiser: (filePath: string, content: string) => string): {
+    validateFolderWithCustomiser: (folderPath: string) => Promise<boolean>;
+    errorSpy: jest.SpyInstance;
+} {
+    const errorSpy = jest.fn();
+
+    async function validateFolderWithCustomiser(folderPath: string): Promise<boolean> {
+        const files = await listFilesRelativeToFolder(folderPath);
+        const getFileContent = async (filePath: string, options?: GetFileContentOptionsType) => {
+            const content = await readFile(path.resolve(folderPath, filePath), options);
+            return fileCustomiser(filePath, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+        };
+        const getFileSize = async (filePath: string) => getSize(path.resolve(folderPath, filePath));
+        return validate(files, getFileContent, getFileSize, (errorMessage) => {
+            errorSpy(errorMessage);
+        });
+    }
+
+    return { validateFolderWithCustomiser: validateFolderWithCustomiser, errorSpy: errorSpy };
+}

--- a/test/validate.anchor.test.ts
+++ b/test/validate.anchor.test.ts
@@ -1,0 +1,45 @@
+import { createValidator } from './test-utils';
+
+describe('validate anchor', () => {
+    it('should pass on minimal sample with anchor property', async () => {
+        const { validateFolderWithCustomiser } = createValidator((filePath: string, content: string) => {
+            if (filePath === 'components-definition.json') {
+                const componentsDefinition = JSON.parse(content);
+                componentsDefinition.components[0].properties.push('anchor');
+                componentsDefinition.componentProperties.push({
+                    name: 'anchor',
+                    label: 'Anchor',
+                    control: {
+                        type: 'anchor',
+                    },
+                    dataType: 'data',
+                });
+                return JSON.stringify(componentsDefinition);
+            }
+            return content;
+        });
+
+        expect(await validateFolderWithCustomiser('./test/resources/minimal-sample-next')).toBe(true);
+    });
+
+    it('should not pass on minimal sample with anchor property and data type other than "data"', async () => {
+        const { validateFolderWithCustomiser } = createValidator((filePath: string, content: string) => {
+            if (filePath === 'components-definition.json') {
+                const componentsDefinition = JSON.parse(content);
+                componentsDefinition.components[0].properties.push('anchor');
+                componentsDefinition.componentProperties.push({
+                    name: 'anchor',
+                    label: 'Anchor',
+                    control: {
+                        type: 'anchor',
+                    },
+                    dataType: 'styles',
+                });
+                return JSON.stringify(componentsDefinition);
+            }
+            return content;
+        });
+
+        expect(await validateFolderWithCustomiser('./test/resources/minimal-sample-next')).toBe(false);
+    });
+});

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -1,28 +1,8 @@
-import * as path from 'path';
-import { validate, validateFolder, getValidators, validatePackageSize, readFile, getSize } from '../lib/validate';
+import { validateFolder, getValidators, validatePackageSize } from '../lib/validate';
 import * as chalk from 'chalk';
-import { listFilesRelativeToFolder } from '../lib/util/files';
-import { GetFileContentOptionsType } from '../lib/models';
+import { createValidator } from './test-utils';
 
 describe('validateFolder', () => {
-    function createValidator(fileCustomiser: (filePath: string, content: string) => string) {
-        const errorSpy = jest.fn();
-
-        async function validateFolderWithCustomiser(folderPath: string): Promise<boolean> {
-            const files = await listFilesRelativeToFolder(folderPath);
-            const getFileContent = async (filePath: string, options?: GetFileContentOptionsType) => {
-                const content = await readFile(path.resolve(folderPath, filePath), options);
-                return fileCustomiser(filePath, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
-            };
-            const getFileSize = async (filePath: string) => getSize(path.resolve(folderPath, filePath));
-            return validate(files, getFileContent, getFileSize, (errorMessage) => {
-                errorSpy(errorMessage);
-            });
-        }
-
-        return { validateFolderWithCustomiser: validateFolderWithCustomiser, errorSpy: errorSpy };
-    }
-
     it('should pass on minimal sample', async () => {
         expect(await validateFolder('./test/resources/minimal-sample')).toBe(true);
     });

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -63,7 +63,18 @@ describe('PropertiesValidator', () => {
         };
     }
 
-    function createConditionalProperty(children: any[]) {
+    function createAnchorProperty(): ComponentProperty {
+        return {
+            name: 'anchorProperty',
+            label: 'Anchor',
+            control: {
+                type: 'anchor',
+            },
+            dataType: 'data',
+        };
+    }
+
+    function createConditionalProperty(children: unknown[]) {
         return {
             name: 'conditionalProperty',
             control: {
@@ -386,6 +397,50 @@ describe('PropertiesValidator', () => {
             });
             validator.validate();
             expect(errorSpy).toHaveBeenCalledWith(`Cannot use dataType "studio-object" with control type "text"`);
+        });
+    });
+
+    describe('anchor property', () => {
+        it('should pass with dataType "studio-object"', () => {
+            const prop = createAnchorProperty();
+            prop.dataType = 'data';
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.10.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not pass with dataType other than "data"', () => {
+            const prop = createAnchorProperty();
+            prop.dataType = 'styles';
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.10.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).toHaveBeenCalledWith(
+                `Anchor property "anchorProperty" cannot use dataType "styles", only dataType "data" is allowed`,
+            );
+        });
+
+        it('should allow child properties on anchor property', () => {
+            const prop = createAnchorProperty();
+            prop.dataType = 'data';
+            prop.childProperties = [
+                {
+                    matchType: 'exact-value',
+                    matchExpression: 'some arbitrary value',
+                    properties: [createTextProperty()],
+                },
+            ];
+            const { validator, errorSpy } = createPropertiesValidator({
+                version: '1.10.0',
+                properties: [prop],
+            });
+            validator.validate();
+            expect(errorSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -401,7 +401,7 @@ describe('PropertiesValidator', () => {
     });
 
     describe('anchor property', () => {
-        it('should pass with dataType "studio-object"', () => {
+        it('should pass with dataType "data"', () => {
             const prop = createAnchorProperty();
             prop.dataType = 'data';
             const { validator, errorSpy } = createPropertiesValidator({

--- a/test/validators/properties-validator.test.ts
+++ b/test/validators/properties-validator.test.ts
@@ -430,8 +430,7 @@ describe('PropertiesValidator', () => {
             prop.dataType = 'data';
             prop.childProperties = [
                 {
-                    matchType: 'exact-value',
-                    matchExpression: 'some arbitrary value',
+                    matchType: 'any-value',
                     properties: [createTextProperty()],
                 },
             ];


### PR DESCRIPTION
- Introduce "anchor" control type (experimental)
- Support child properties and data type "data"
- Available in "1.10.0-next" (not implemented yet)

When the control is added, you will have two buttons to focus or delete the created anchor (creation happens through the text toolbar). Similar to Inception:
![Screenshot 2022-08-10 at 08 34 38](https://user-images.githubusercontent.com/6328924/183879727-2776d251-b489-42cb-9a37-408350712aa5.png)

The properties from Inception should be defined as child properties. For this a new match type is introduced "any-value", as we don't have a value to perform an exact match.

