### PR TITLE
Bump validator version to 1.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@woodwing/studio-component-set-tools",
-      "version": "1.19.1",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woodwing/studio-component-set-tools",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Validation module for Studio Digital Editor component sets.",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Include experimental definition for "anchor" property and adds "any-value" match type. Available in component definition schema 1.10.0-next.