### PR TITLE
CSH-9935: Update components definition so that the group also support…

### DIFF
--- a/lib/models/components-definition.ts
+++ b/lib/models/components-definition.ts
@@ -103,6 +103,15 @@ export interface ComponentDefinition {
 
                 /** names of components in this group */
                 components: string[];
+
+                /** An optional logo which can be shown in the component chooser dialog */
+                logo?: {
+                    /** The icon to be shown */
+                    icon: string;
+
+                    /** The link to which the logo will direct to when the icon is clicked by a user */
+                    link?: string;
+                };
                 [k: string]: unknown;
             }[];
             autofill?: {


### PR DESCRIPTION
Update components definition so that the group also supports the new optional logo attribute.

Seems like we forgot to update this definition in [this PR](https://github.com/WoodWing/studio-component-set-tools/pull/179) as well when we added the icon attribute to the groups.