### PR TITLE
Rename chart-properties to just chart in validators

### DIFF
--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -215,13 +215,13 @@ export function isMediaProperties(
 }
 
 /**
- * Enables chart-properties for an doc-chart directive
+ * Enables chart for an doc-chart directive
  */
 export interface ComponentPropertyControlChartProperties {
-    type: 'chart-properties';
+    type: 'chart';
 }
 export function isChart(control: ComponentPropertyControl): control is ComponentPropertyControlChartProperties {
-    return control.type === 'chart-properties';
+    return control.type === 'chart';
 }
 
 /**

--- a/lib/validators/directive-properties-validator.ts
+++ b/lib/validators/directive-properties-validator.ts
@@ -7,7 +7,7 @@
 import { Validator } from './validator';
 import { DirectiveType } from '../models';
 
-const CONTROLS = ['image-editor', 'interactive', 'media-properties', 'chart-properties'];
+const CONTROLS = ['image-editor', 'interactive', 'media-properties', 'chart'];
 
 export class DirectivePropertiesValidator extends Validator {
     async validate(): Promise<void> {

--- a/lib/validators/doc-chart-validator.ts
+++ b/lib/validators/doc-chart-validator.ts
@@ -3,9 +3,9 @@
  *
  * Rules:
  *  - A component is not allowed to have more than one doc-chart directive.
- *  - A component with 1 doc-chart directive -must- have a property control type "chart-properties"
- *  - A component property with a "chart-properties" control type MUST be applied to a "chart" directive
- *  - A component without a doc-chart directive can't have any "chart-properties" control types
+ *  - A component with 1 doc-chart directive -must- have a property control type "chart"
+ *  - A component property with a "chart" control type MUST be applied to a "chart" directive
+ *  - A component without a doc-chart directive can't have any "chart" control types
  */
 
 import { Validator } from './validator';
@@ -34,7 +34,7 @@ export class DocChartValidator extends Validator {
     private validateComponentWithoutChartDirective(component: Component) {
         if (this.countChartPropertiesProperties(component) > 0) {
             this.error(
-                `Component "${component.name}" has a "chart-properties" control type, but only components with a "doc-chart" directive can have a property with this control type`,
+                `Component "${component.name}" has a "chart" control type, but only components with a "doc-chart" directive can have a property with this control type`,
             );
         }
     }
@@ -44,7 +44,7 @@ export class DocChartValidator extends Validator {
             this.error(
                 `Component "${
                     component.name
-                }" with "doc-chart" directive must have exactly one "chart-properties" property (found ${this.countChartPropertiesProperties(
+                }" with "doc-chart" directive must have exactly one "chart" property (found ${this.countChartPropertiesProperties(
                     component,
                 )})`,
             );
@@ -60,7 +60,7 @@ export class DocChartValidator extends Validator {
     private validateChartProperty(component: Component, chartProperty: ComponentProperty) {
         if (!chartProperty.directiveKey) {
             this.error(
-                `Component "${component.name}" must configure "directiveKey" for the property with control type "chart-properties"`,
+                `Component "${component.name}" must configure "directiveKey" for the property with control type "chart"`,
             );
             return;
         }
@@ -68,7 +68,7 @@ export class DocChartValidator extends Validator {
         const directive = component.directives[chartProperty.directiveKey];
         if (!directive || directive.type !== DirectiveType.chart) {
             this.error(
-                `Component "${component.name}" has a control type "chart-properties" applied to the wrong directive, which can only be used with "doc-chart" directives`,
+                `Component "${component.name}" has a control type "chart" applied to the wrong directive, which can only be used with "doc-chart" directives`,
             );
         }
     }
@@ -77,13 +77,13 @@ export class DocChartValidator extends Validator {
         return Object.values(component.directives).filter((directive) => directive.type === DirectiveType.chart).length;
     }
 
-    /** Count number of "chart-properties" properties */
+    /** Count number of "chart" properties */
     private countChartPropertiesProperties(component: Component): number {
         return this.chartPropertiesProperties(component).length;
     }
 
-    /** Get "chart-properties" properties definitions (collection of nested properties behaving as a single property) */
+    /** Get "chart" properties definitions (collection of nested properties behaving as a single property) */
     private chartPropertiesProperties(component: Component) {
-        return Object.values(component.properties).filter((property) => property.control.type === 'chart-properties');
+        return Object.values(component.properties).filter((property) => property.control.type === 'chart');
     }
 }

--- a/test/validators/doc-chart-validator.test.ts
+++ b/test/validators/doc-chart-validator.test.ts
@@ -22,7 +22,7 @@ describe('DocChartValidator', () => {
                             name: 'chartproperty',
                             directiveKey: 'd1',
                             control: {
-                                type: 'chart-properties',
+                                type: 'chart',
                             },
                         },
                     ],
@@ -55,7 +55,7 @@ describe('DocChartValidator', () => {
 
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component "Infographic" with "doc-chart" directive must have exactly one "chart-properties" property (found 0)`,
+                `Component "Infographic" with "doc-chart" directive must have exactly one "chart" property (found 0)`,
             );
         });
 
@@ -83,7 +83,7 @@ describe('DocChartValidator', () => {
             );
         });
 
-        it('should fail if a component property with a chart-properties control type is not applied to a chart directive', () => {
+        it('should fail if a component property with a chart control type is not applied to a chart directive', () => {
             definition.components.wrongdirectivekey = {
                 name: 'wrongdirectivekey',
                 directives: {
@@ -101,7 +101,7 @@ describe('DocChartValidator', () => {
                         name: 'chartproperty',
                         directiveKey: 'd1',
                         control: {
-                            type: 'chart-properties',
+                            type: 'chart',
                             logo: 'logos/chart.svg',
                             link: 'www.chart.com',
                         },
@@ -110,11 +110,11 @@ describe('DocChartValidator', () => {
             };
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component "wrongdirectivekey" has a control type "chart-properties" applied to the wrong directive, which can only be used with "doc-chart" directives`,
+                `Component "wrongdirectivekey" has a control type "chart" applied to the wrong directive, which can only be used with "doc-chart" directives`,
             );
         });
 
-        it('should fail in case a "chart-properties" property does not have a directive key', () => {
+        it('should fail in case a "chart" property does not have a directive key', () => {
             definition.components.nodirectivekey = {
                 name: 'nodirectivekey',
                 directives: {
@@ -127,24 +127,24 @@ describe('DocChartValidator', () => {
                     {
                         name: 'chartproperty',
                         control: {
-                            type: 'chart-properties',
+                            type: 'chart',
                         },
                     },
                 ],
             };
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component "nodirectivekey" must configure "directiveKey" for the property with control type "chart-properties"`,
+                `Component "nodirectivekey" must configure "directiveKey" for the property with control type "chart"`,
             );
         });
 
-        it('should fail in case a component without a chart directive has "chart-properties" property', () => {
+        it('should fail in case a component without a chart directive has "chart" property', () => {
             definition.components.body.properties = [
                 {
                     name: 'chartproperty',
                     directiveKey: 'd1',
                     control: {
-                        type: 'chart-properties',
+                        type: 'chart',
                         logo: 'logos/chart.svg',
                         link: 'www.chart.com',
                     },
@@ -153,7 +153,7 @@ describe('DocChartValidator', () => {
 
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Component "body" has a "chart-properties" control type, but only components with a "doc-chart" directive can have a property with this control type`,
+                `Component "body" has a "chart" control type, but only components with a "doc-chart" directive can have a property with this control type`,
             );
         });
     });


### PR DESCRIPTION
There was a difference between the schema definition declaring `chart` in componentPropertyDefinition while validators were still checking for the old value `chart-properties`. 
Tests did not complain as we only test minimal sample, which don't include all components.