### PR TITLE
CSH-10045: Add `chartType` property

### DIFF
--- a/lib/components-schema-v1_11_x.ts
+++ b/lib/components-schema-v1_11_x.ts
@@ -328,11 +328,15 @@ const componentPropertyDefinition: {
             },
             {
                 additionalProperties: false,
-                required: ['type'],
+                required: ['type', 'chartType'],
                 properties: {
                     type: {
                         enum: ['chart'],
                         description: 'Adds chart options',
+                    },
+                    chartType: {
+                        type: 'string',
+                        description: 'Chart provider',
                     },
                 },
             },

--- a/lib/components-schema-v1_11_x.ts
+++ b/lib/components-schema-v1_11_x.ts
@@ -335,7 +335,7 @@ const componentPropertyDefinition: {
                         description: 'Adds chart options',
                     },
                     chartType: {
-                        type: 'string',
+                        enum: ['infogram'],
                         description: 'Chart provider',
                     },
                 },

--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -219,6 +219,10 @@ export function isMediaProperties(
  */
 export interface ComponentPropertyControlChartProperties {
     type: 'chart';
+    /**
+     * Defines chart provider.
+     */
+    chartType: string;
 }
 export function isChart(control: ComponentPropertyControl): control is ComponentPropertyControlChartProperties {
     return control.type === 'chart';

--- a/lib/models/component-property-controls.ts
+++ b/lib/models/component-property-controls.ts
@@ -220,9 +220,9 @@ export function isMediaProperties(
 export interface ComponentPropertyControlChartProperties {
     type: 'chart';
     /**
-     * Defines chart provider.
+     * Defines chart provider. For now only supports 'infogram'
      */
-    chartType: string;
+    chartType: 'infogram';
 }
 export function isChart(control: ComponentPropertyControl): control is ComponentPropertyControlChartProperties {
     return control.type === 'chart';

--- a/lib/validators/doc-chart-validator.ts
+++ b/lib/validators/doc-chart-validator.ts
@@ -10,6 +10,7 @@
 
 import { Validator } from './validator';
 import { ComponentProperty, DirectiveType, Component } from '../models';
+import { ComponentPropertyControlChartProperties } from '../models/component-property-controls';
 
 export class DocChartValidator extends Validator {
     async validate(): Promise<void> {
@@ -53,15 +54,25 @@ export class DocChartValidator extends Validator {
 
         // Check whether the chart-properties control type property is applied to the doc-chart directive.
         for (const chartProperty of Object.values(this.chartPropertiesProperties(component))) {
-            this.validateChartProperty(component, chartProperty);
+            this.validateChartProperty(
+                component,
+                chartProperty as ComponentProperty<ComponentPropertyControlChartProperties>,
+            );
         }
     }
 
-    private validateChartProperty(component: Component, chartProperty: ComponentProperty) {
+    private validateChartProperty(
+        component: Component,
+        chartProperty: ComponentProperty<ComponentPropertyControlChartProperties>,
+    ) {
         if (!chartProperty.directiveKey) {
             this.error(
                 `Component "${component.name}" must configure "directiveKey" for the property with control type "chart"`,
             );
+            return;
+        }
+        if (!chartProperty.control.chartType) {
+            this.error(`Component "${component.name}" is missing mandatory 'chartType' property`);
             return;
         }
 

--- a/lib/validators/doc-chart-validator.ts
+++ b/lib/validators/doc-chart-validator.ts
@@ -71,10 +71,6 @@ export class DocChartValidator extends Validator {
             );
             return;
         }
-        if (!chartProperty.control.chartType) {
-            this.error(`Component "${component.name}" is missing mandatory 'chartType' property`);
-            return;
-        }
 
         const directive = component.directives[chartProperty.directiveKey];
         if (!directive || directive.type !== DirectiveType.chart) {

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -3,19 +3,24 @@ import { validate, readFile, getSize } from '../lib/validate';
 import { listFilesRelativeToFolder } from '../lib/util/files';
 import { GetFileContentOptionsType } from '../lib/models';
 
-export function createValidator(fileCustomiser: (filePath: string, content: string) => string): {
+export function createValidator(
+    fileCustomiser: (filePath: string, content: string) => string,
+    extraFiles: string[] = [],
+): {
     validateFolderWithCustomiser: (folderPath: string) => Promise<boolean>;
     errorSpy: jest.SpyInstance;
 } {
     const errorSpy = jest.fn();
 
     async function validateFolderWithCustomiser(folderPath: string): Promise<boolean> {
-        const files = await listFilesRelativeToFolder(folderPath);
+        const files = new Set([...(await listFilesRelativeToFolder(folderPath)), ...(extraFiles ?? [])]);
         const getFileContent = async (filePath: string, options?: GetFileContentOptionsType) => {
+            if (extraFiles.includes(filePath)) return fileCustomiser(filePath, '');
             const content = await readFile(path.resolve(folderPath, filePath), options);
             return fileCustomiser(filePath, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
         };
-        const getFileSize = async (filePath: string) => getSize(path.resolve(folderPath, filePath));
+        const getFileSize = async (filePath: string) =>
+            extraFiles.includes(filePath) ? 0 : getSize(path.resolve(folderPath, filePath));
         return validate(files, getFileContent, getFileSize, (errorMessage) => {
             errorSpy(errorMessage);
         });

--- a/test/validate.chart.test.ts
+++ b/test/validate.chart.test.ts
@@ -38,7 +38,7 @@ describe('validate chart', () => {
             },
             ['templates/html/chart.html', 'styles/_chart.scss'],
         );
-
+        expect(errorSpy).not.toHaveBeenCalled();
         expect(await validateFolderWithCustomiser('./test/resources/minimal-sample-next')).toBe(true);
     });
 });

--- a/test/validate.chart.test.ts
+++ b/test/validate.chart.test.ts
@@ -1,4 +1,5 @@
 import { createValidator } from './test-utils';
+import * as path from 'path';
 
 describe('validate chart', () => {
     it('should pass on minimal sample with chart property', async () => {
@@ -36,7 +37,7 @@ describe('validate chart', () => {
                 }
                 return content;
             },
-            ['templates/html/chart.html', 'styles/_chart.scss'],
+            [path.normalize('templates/html/chart.html'), path.normalize('styles/_chart.scss')],
         );
         expect(errorSpy).not.toHaveBeenCalled();
         expect(await validateFolderWithCustomiser('./test/resources/minimal-sample-next')).toBe(true);

--- a/test/validate.chart.test.ts
+++ b/test/validate.chart.test.ts
@@ -29,10 +29,10 @@ describe('validate chart', () => {
                     });
                     return JSON.stringify(componentsDefinition);
                 }
-                if (filePath === 'templates/html/chart.html') {
+                if (filePath === path.normalize('templates/html/chart.html')) {
                     return `<figure class="chart"><div doc-chart="chart"></div></figure>`;
                 }
-                if (filePath === 'styles/_chart.scss') {
+                if (filePath === path.normalize('styles/_chart.scss')) {
                     return `.chart { color: deeppink; }`;
                 }
                 return content;

--- a/test/validate.chart.test.ts
+++ b/test/validate.chart.test.ts
@@ -1,0 +1,44 @@
+import { createValidator } from './test-utils';
+
+describe('validate chart', () => {
+    it('should pass on minimal sample with chart property', async () => {
+        const { validateFolderWithCustomiser, errorSpy } = createValidator(
+            (filePath: string, content: string) => {
+                if (filePath === 'components-definition.json') {
+                    const componentsDefinition = JSON.parse(content);
+                    componentsDefinition.components.push({
+                        name: 'chart',
+                        label: 'Chart Label',
+                        icon: 'icons/component.svg',
+                        properties: [
+                            {
+                                name: 'chart',
+                                directiveKey: 'chart',
+                            },
+                        ],
+                    });
+                    componentsDefinition.componentProperties.push({
+                        name: 'chart',
+                        label: 'Chart property example',
+                        control: {
+                            type: 'chart',
+                            chartType: 'infogram',
+                        },
+                        dataType: 'doc-chart',
+                    });
+                    return JSON.stringify(componentsDefinition);
+                }
+                if (filePath === 'templates/html/chart.html') {
+                    return `<figure class="chart"><div doc-chart="chart"></div></figure>`;
+                }
+                if (filePath === 'styles/_chart.scss') {
+                    return `.chart { color: deeppink; }`;
+                }
+                return content;
+            },
+            ['templates/html/chart.html', 'styles/_chart.scss'],
+        );
+
+        expect(await validateFolderWithCustomiser('./test/resources/minimal-sample-next')).toBe(true);
+    });
+});

--- a/test/validators/doc-chart-validator.test.ts
+++ b/test/validators/doc-chart-validator.test.ts
@@ -23,7 +23,7 @@ describe('DocChartValidator', () => {
                             directiveKey: 'd1',
                             control: {
                                 type: 'chart',
-                                chartType: 'someProvider',
+                                chartType: 'infogram',
                             },
                         },
                     ],
@@ -103,7 +103,7 @@ describe('DocChartValidator', () => {
                         directiveKey: 'd1',
                         control: {
                             type: 'chart',
-                            chartType: 'someProvider',
+                            chartType: 'infogram',
                             logo: 'logos/chart.svg',
                             link: 'www.chart.com',
                         },
@@ -113,37 +113,6 @@ describe('DocChartValidator', () => {
             validator.validate();
             expect(error).toHaveBeenCalledWith(
                 `Component "wrongdirectivekey" has a control type "chart" applied to the wrong directive, which can only be used with "doc-chart" directives`,
-            );
-        });
-
-        it('should fail if a component property with a chart control type is missing mandatory property "chartType".', () => {
-            definition.components.wrongdirectivekey = {
-                name: 'chartMissingChartTypeProp',
-                directives: {
-                    d1: {
-                        type: 'editable',
-                        tag: 'p',
-                    },
-                    d2: {
-                        type: 'chart',
-                        tag: 'div',
-                    },
-                },
-                properties: [
-                    {
-                        name: 'chartproperty',
-                        directiveKey: 'd1',
-                        control: {
-                            type: 'chart',
-                            logo: 'logos/chart.svg',
-                            link: 'www.chart.com',
-                        },
-                    },
-                ],
-            };
-            validator.validate();
-            expect(error).toHaveBeenCalledWith(
-                `Component "chartMissingChartTypeProp" is missing mandatory 'chartType' property`,
             );
         });
 
@@ -178,7 +147,7 @@ describe('DocChartValidator', () => {
                     directiveKey: 'd1',
                     control: {
                         type: 'chart',
-                        chartType: 'someProvider',
+                        chartType: 'infogram',
                         logo: 'logos/chart.svg',
                         link: 'www.chart.com',
                     },

--- a/test/validators/doc-chart-validator.test.ts
+++ b/test/validators/doc-chart-validator.test.ts
@@ -23,6 +23,7 @@ describe('DocChartValidator', () => {
                             directiveKey: 'd1',
                             control: {
                                 type: 'chart',
+                                chartType: 'someProvider',
                             },
                         },
                     ],
@@ -102,6 +103,7 @@ describe('DocChartValidator', () => {
                         directiveKey: 'd1',
                         control: {
                             type: 'chart',
+                            chartType: 'someProvider',
                             logo: 'logos/chart.svg',
                             link: 'www.chart.com',
                         },
@@ -111,6 +113,37 @@ describe('DocChartValidator', () => {
             validator.validate();
             expect(error).toHaveBeenCalledWith(
                 `Component "wrongdirectivekey" has a control type "chart" applied to the wrong directive, which can only be used with "doc-chart" directives`,
+            );
+        });
+
+        it('should fail if a component property with a chart control type is missing mandatory property "chartType".', () => {
+            definition.components.wrongdirectivekey = {
+                name: 'chartMissingChartTypeProp',
+                directives: {
+                    d1: {
+                        type: 'editable',
+                        tag: 'p',
+                    },
+                    d2: {
+                        type: 'chart',
+                        tag: 'div',
+                    },
+                },
+                properties: [
+                    {
+                        name: 'chartproperty',
+                        directiveKey: 'd1',
+                        control: {
+                            type: 'chart',
+                            logo: 'logos/chart.svg',
+                            link: 'www.chart.com',
+                        },
+                    },
+                ],
+            };
+            validator.validate();
+            expect(error).toHaveBeenCalledWith(
+                `Component "chartMissingChartTypeProp" is missing mandatory 'chartType' property`,
             );
         });
 
@@ -145,6 +178,7 @@ describe('DocChartValidator', () => {
                     directiveKey: 'd1',
                     control: {
                         type: 'chart',
+                        chartType: 'someProvider',
                         logo: 'logos/chart.svg',
                         link: 'www.chart.com',
                     },


### PR DESCRIPTION
As requested in this PR https://github.com/WoodWing/contentstation/pull/4809#discussion_r1422291715

In case we want to support different chartTypes or chart providers, not just **Infogram**, then we have a way to distinguish them. 