### PR TITLE
CSH-10063-Add-percentage-as-unit-in-for-text-property-fields

### DIFF
--- a/lib/components-schema-v1_11_x.ts
+++ b/lib/components-schema-v1_11_x.ts
@@ -232,7 +232,7 @@ const componentPropertyDefinition: {
                     },
                     unit: {
                         type: 'string',
-                        description: 'Unit type like em, px etc',
+                        description: 'Unit type like em, px, % etc',
                     },
                     inputPlaceholder: labelProperty('Input placeholder'),
                     readonly: {

--- a/lib/validators/unit-type-validator.ts
+++ b/lib/validators/unit-type-validator.ts
@@ -5,7 +5,7 @@
 import { Validator } from './validator';
 import { Component, ComponentProperty } from '../models';
 
-const TYPES = ['em', 'px'];
+const TYPES = ['em', 'px', '%'];
 const TYPES_REGEXP = new RegExp(`^(${TYPES.join('|')})$`, 'i');
 
 export class UnitTypeValidator extends Validator {

--- a/test/validators/unit-type-validator.test.ts
+++ b/test/validators/unit-type-validator.test.ts
@@ -30,6 +30,13 @@ describe('UnitTypeValidator', () => {
                                 unit: 'eM', // test if it is case-insensitive
                             },
                         },
+                        {
+                            name: 'p4',
+                            control: {
+                                type: 'text',
+                                unit: '%',
+                            },
+                        },
                     ],
                 },
             },
@@ -46,7 +53,7 @@ describe('UnitTypeValidator', () => {
             definition.components.c1.properties[1].control.unit = 'xy';
             validator.validate();
             expect(error).toHaveBeenCalledWith(
-                `Property "p2" has unacceptable unit type "xy", only "em,px" are allowed`,
+                `Property "p2" has unacceptable unit type "xy", only "em,px,%" are allowed`,
             );
         });
     });


### PR DESCRIPTION
In order to customise the chart-component height, we need to be able to set a `padding-bottom` percentage, this way we can respect the aspect ratio, that is needed for any chart ([similar to the embed component](https://github.com/WoodWing/csde-components-boilerplate/blob/fd4b1b8b123737aab3f4fe546007d552fc0b60a1/component-sets/default-components/styles/_embed.scss#L8)).