### PR TITLE
Remove unneeded z-index

### DIFF
--- a/test/resources/restrict-children-sample/styles/_container.scss
+++ b/test/resources/restrict-children-sample/styles/_container.scss
@@ -60,13 +60,11 @@
             float: left;
             clear: left;
             width: 50%;
-            z-index: 1;
         }
         &._right {
             float: right;
             clear: right;
             width: 50%;
-            z-index: 1;
         }
     }
 }

--- a/test/resources/restrict-children-sample/styles/_container2.scss
+++ b/test/resources/restrict-children-sample/styles/_container2.scss
@@ -60,13 +60,11 @@
             float: left;
             clear: left;
             width: 50%;
-            z-index: 1;
         }
         &._right {
             float: right;
             clear: right;
             width: 50%;
-            z-index: 1;
         }
     }
 }

--- a/test/resources/restrict-children-sample/styles/_image.scss
+++ b/test/resources/restrict-children-sample/styles/_image.scss
@@ -117,13 +117,11 @@
             clear: left;
             width: calc(50% - 15px);
             margin-right: 15px;
-            z-index: 1;
         }
         &._right {
             float: right;
             clear: right;
             width: 50%;
-            z-index: 1;
         }
     }
 }


### PR DESCRIPTION

z-index is was on image component causing an undesired behaviour, see video:

https://github.com/WoodWing/studio-component-set-tools/assets/29701574/2c2ea44a-54e6-4d4f-8c93-e9f55093109c

Images with positioning `left` or `right` had a `z-index: 1` making them appear over the infogram iframe.

For container component this z-index is also removed since it is not having any effect since the placeholder has position static:
<img width="563" alt="Pasted Graphic 23" src="https://github.com/WoodWing/studio-component-set-tools/assets/29701574/80cb9a16-3f9b-4658-b70e-d4333f2d3f4a">


I could not find any drawbacks when removing z-index, but I could be missing some scenario, for this reason I would like some input from @ruudjungbacker since he added [those](https://github.com/WoodWing/studio-component-set-tools/commit/d8a3a693efd01c4df3a118236e2887bd4046e4b6#diff-62e3984ddfe765bcb72eeed916a342cef119f83e2ac8d16bfdcc26c9d6fc81f4) z-index a while ago.